### PR TITLE
Removed dev dependencies from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 numpy = "^1.15"
-pytest = { version = "^3.6", optional = true }
-coverage = { version = "^4.5", optional = true }
-sphinx = { version = "^2.2", optional = true }
-sphinxcontrib-katex = { version = "^0.5.1", optional = true }
-toml = { version = "^0.10.0", optional = true }
 
 [tool.poetry.extras]
 test = ["pytest", "coverage"]
@@ -44,6 +39,11 @@ black = { version = ">=20-beta.0", python = "^3.6" }
 pep8-naming = ">=0.7"
 isort = { version = "^5", python = "^3.6" }
 pydocstyle = ">=5"
+pytest = { version = "^3.6" }
+coverage = { version = "^4.5" }
+sphinx = { version = "^2.2" }
+sphinxcontrib-katex = { version = "^0.5.1" }
+toml = { version = "^0.10.0" }
 
 [tool.poetry.scripts]
 berny = "berny.cli:main"


### PR DESCRIPTION
Hi @jhrmnn . Thanks for your work on `berny`!

I've updated your `pyproject.toml` file to remove developer-only dependencies from your main dependencies. Having pytest, sphinx, toml, etc. in your dependencies adds them to builds when one only wants a library installation of the package (for example when installing from PyPi). This helps avoid dependency conflicts and keeps installs clean and lightweight.

I'd also recommend adding a `poetry.lock` file to your repo so that developer builds are reproducible. I'm omitted that from this PR but let me know if you'd like it added and I'll make a new PR with the lock file I generated from the updated `pyproject.toml`.

If you accept this PR would you be up for releasing a version `0.6.4` on PyPi with the update? Would be great to have a slimmed down `berny` with only user dependencies available :)

Thanks so much!