### PR TITLE
Add NumPy 2 support and drop Python 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,22 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for NumPy 2.
-- Test matrix runs on Python 3.9 through 3.13.
 
 ### Changed
 
 - Minimum supported Python version raised to 3.9.
-- `berny.species_data` now uses `importlib.resources` instead of the
-  deprecated `pkg_resources`.
-- Renamed `berny.Math.FindrootException` to `berny.Math.FindrootError`.
-- Build backend switched to `poetry_dynamic_versioning.backend` so the
-  dynamic version is populated for PEP 517 builds (`pip install`,
-  `python -m build`), not only for `poetry build`.
-
-### Fixed
-
-- CI workflows updated for current GitHub Actions, MOPAC switched to
-  the open-source release at `openmopac/mopac`.
+- `berny.Math.FindrootException` renamed to `berny.Math.FindrootError`.
+- Dropped the runtime dependency on `setuptools` (`pkg_resources`).
 
 ## [0.6.3] - 2021-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for NumPy 2.
+- Test matrix runs on Python 3.9 through 3.13.
+
+### Changed
+
+- Minimum supported Python version raised to 3.9.
+- `berny.species_data` now uses `importlib.resources` instead of the
+  deprecated `pkg_resources`.
+- Renamed `berny.Math.FindrootException` to `berny.Math.FindrootError`.
+- Build backend switched to `poetry_dynamic_versioning.backend` so the
+  dynamic version is populated for PEP 517 builds (`pip install`,
+  `python -m build`), not only for `poetry build`.
+
+### Fixed
+
+- CI workflows updated for current GitHub Actions, MOPAC switched to
+  the open-source release at `openmopac/mopac`.
+
 ## [0.6.3] - 2021-02-22
 
 ### Fixed
 
 - CLI
 
-[unreleased]: https://github.com/deepqmc/deepqmc/compare/0.6.3...HEAD
-[0.6.3]: https://github.com/deepqmc/deepqmc/releases/tag/0.6.3
+[unreleased]: https://github.com/jhrmnn/pyberny/compare/0.6.3...HEAD
+[0.6.3]: https://github.com/jhrmnn/pyberny/releases/tag/0.6.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-numpy = "^1.15"
+numpy = ">=1.15,<3"
 pytest = { version = ">=6", optional = true }
 coverage = { version = ">=6", optional = true }
 sphinx = { version = ">=5", optional = true }


### PR DESCRIPTION
## Summary
This PR updates the project to support NumPy 2 while raising the minimum Python version to 3.9 and removing the runtime dependency on setuptools.

## Key Changes
- **NumPy 2 support**: Updated numpy dependency constraint from `^1.15` to `>=1.15,<3` to allow NumPy 2.x versions
- **Python version**: Raised minimum supported Python version to 3.9 (from 3.8)
- **Removed setuptools dependency**: Dropped the runtime dependency on `setuptools` and `pkg_resources`
- **API change**: Renamed `berny.Math.FindrootException` to `berny.Math.FindrootError` for consistency
- **CI updates**: Added Python 3.13 to the test matrix

## Implementation Details
- The numpy version constraint change is backward compatible with existing NumPy 1.x installations while enabling support for the new NumPy 2.x major version
- The exception rename is a breaking change for users catching `FindrootException`, but aligns with Python naming conventions (using `Error` suffix for exception classes)
- Removal of setuptools dependency reduces external runtime dependencies

https://claude.ai/code/session_01AUPLCk6LQTeSbuf8MTCMVC