### PR TITLE
ci: add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+MOPAC_VERSION=23.2.5
+MOPAC_DIR="$CLAUDE_PROJECT_DIR/.claude/mopac"
+
+if [ ! -x "$MOPAC_DIR/bin/mopac" ]; then
+  mkdir -p "$MOPAC_DIR"
+  cd "$MOPAC_DIR"
+  wget -q "https://github.com/openmopac/mopac/releases/download/v${MOPAC_VERSION}/mopac-${MOPAC_VERSION}-linux.tar.gz"
+  tar --strip-components=1 -xzf "mopac-${MOPAC_VERSION}-linux.tar.gz"
+  rm "mopac-${MOPAC_VERSION}-linux.tar.gz"
+fi
+
+echo "export PATH=\"$MOPAC_DIR/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+echo "export LD_LIBRARY_PATH=\"$MOPAC_DIR/lib:\${LD_LIBRARY_PATH:-}\"" >> "$CLAUDE_ENV_FILE"
+
+cd "$CLAUDE_PROJECT_DIR"
+pip install -e ".[test]"
+pip install flake8 flake8-bugbear flake8-comprehensions pep8-naming black isort pydocstyle

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /doc/build/
 /htmlcov/
 /poetry.lock
+.claude/mopac/

--- a/src/berny/species_data.py
+++ b/src/berny/species_data.py
@@ -14,13 +14,13 @@ def get_property(idx, name):
             raise KeyError('No species with symbol "{}"'.format(idx)) from None
     else:
         try:
-            value = next(row[name] for row in species_data.values() if row['number'] == idx)
+            value = next(
+                row[name] for row in species_data.values() if row['number'] == idx
+            )
         except StopIteration:
             raise KeyError('No species with number "{}"'.format(idx)) from None
     if value == '':
-        raise KeyError(
-            'No "{}" data for species "{}"'.format(name, idx)
-        )
+        raise KeyError('No "{}" data for species "{}"'.format(name, idx))
     return value
 
 


### PR DESCRIPTION
## Summary

Adds a `SessionStart` hook so a fresh Claude Code on the web session can run the test suite and linters without manual setup.

The hook:
- Downloads open-source MOPAC 23.2.5 into `.claude/mopac/` (cached across runs)
- Exports `PATH` and `LD_LIBRARY_PATH` via `$CLAUDE_ENV_FILE` so `mopac` is discoverable for the test runner
- Runs `pip install -e ".[test]"` plus the dev linter deps (flake8, black, isort, etc., which live in poetry's dev group and aren't reachable through pip extras)
- No-ops outside Claude Code on the web (gated on `$CLAUDE_CODE_REMOTE`)

`.claude/mopac/` is gitignored so the downloaded binary never ends up in the repo.

## Test plan

- [x] Hook runs cleanly from scratch (downloads MOPAC, installs project)
- [x] Hook is idempotent — re-running is a no-op for MOPAC, pip reports "already satisfied"
- [x] `mopac` ends up on `PATH` after sourcing `$CLAUDE_ENV_FILE`
- [x] `pytest tests/test_coords.py` passes
- [x] `flake8 src/berny/Math.py` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01AUPLCk6LQTeSbuf8MTCMVC)_