### PR TITLE
Replace ad-hoc state namespaces with dataclasses; add type hints

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -45,6 +45,7 @@ jobs:
         run: pip install -e ".[test,doc]"
 
       # Lint tools used by .github/workflows/lint.yaml so `flake8`, `black`,
-      # `isort` and `pydocstyle` are available without a network round-trip.
+      # `isort`, `pydocstyle` and `mypy` are available without a network
+      # round-trip.
       - name: Install lint tools
-        run: pip install flake8 flake8-bugbear flake8-comprehensions pep8-naming black isort pydocstyle
+        run: pip install flake8 flake8-bugbear flake8-comprehensions pep8-naming black isort pydocstyle mypy

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,3 +41,15 @@ jobs:
       - name: Install dependencies
         run: pip install pydocstyle
       - run: pydocstyle src
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        # Install the package so mypy picks up bundled NumPy stubs and our own
+        # type hints via the installed module rather than just the source tree.
+        run: pip install mypy -e .
+      - run: mypy

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -51,5 +51,5 @@ jobs:
       - name: Install dependencies
         # Install the package so mypy picks up bundled NumPy stubs and our own
         # type hints via the installed module rather than just the source tree.
-        run: pip install mypy -e .
+        run: pip install -e . mypy
       - run: mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for NumPy 2.
 - Covalent radii for Ce–Yb, Po, At, and Fr–U from Cordero et al., *Dalton Trans.*, 2008, 2832, so that geometries containing these elements no longer crash `InternalCoords`.
+- New `berny.BernyParams` dataclass listing every tunable optimizer parameter; useful for discovery and type-checked construction.
 
 ### Changed
 
 - Minimum supported Python version raised to 3.9.
 - `berny.Math.FindrootException` renamed to `berny.Math.FindrootError`.
 - Dropped the runtime dependency on `setuptools` (`pkg_resources`).
+- Unknown keyword arguments to `Berny()` now raise `TypeError` instead of being silently absorbed.
+
+### Removed
+
+- The module-level `berny.berny.defaults` dict. Use `berny.BernyParams` (or pass overrides as keyword arguments to `Berny()`) instead.
 
 ### Fixed
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -9,7 +9,8 @@ This covers all supported public API.
    :members:
    :exclude-members: Point, send, throw
 
-.. autodata:: berny.berny.defaults
+.. autoclass:: BernyParams
+   :members:
 
 .. autodata:: berny.coords.angstrom
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ black = ">=22"
 pep8-naming = ">=0.13"
 isort = ">=5"
 pydocstyle = ">=6"
+mypy = ">=1"
 
 [tool.poetry.scripts]
 berny = "berny.cli:main"
@@ -55,3 +56,11 @@ pattern = '^(?P<base>\d+\.\d+\.\d+)$'
 [tool.black]
 target-version = ["py39"]
 skip-string-normalization = true
+
+[tool.mypy]
+python_version = "3.9"
+files = ["src/berny"]
+
+[[tool.mypy.overrides]]
+module = ["numpy", "numpy.*"]
+ignore_missing_imports = true

--- a/src/berny/__init__.py
+++ b/src/berny/__init__.py
@@ -1,7 +1,7 @@
 from . import geomlib
-from .berny import Berny
+from .berny import Berny, BernyParams
 from .coords import angstrom
 from .geomlib import Geometry
 from .optimize import optimize
 
-__all__ = ['optimize', 'Berny', 'geomlib', 'Geometry', 'angstrom']
+__all__ = ['optimize', 'Berny', 'BernyParams', 'geomlib', 'Geometry', 'angstrom']

--- a/src/berny/berny.py
+++ b/src/berny/berny.py
@@ -72,10 +72,9 @@ class BernyState:
 
 
 class BernyAdapter(logging.LoggerAdapter):
-    step: int = 0
-
     def __init__(self, logger: logging.Logger) -> None:
         super().__init__(logger, {})
+        self.step: int = 0
 
     def process(self, msg, kwargs):
         return f'{self.step} {msg}', kwargs

--- a/src/berny/berny.py
+++ b/src/berny/berny.py
@@ -1,10 +1,12 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
 import logging
-from collections import namedtuple
 from collections.abc import Generator
-from itertools import chain
+from dataclasses import dataclass, fields
+from typing import Any, NamedTuple
 
 import numpy as np
 from numpy import dot, eye
@@ -12,38 +14,59 @@ from numpy.linalg import norm
 
 from . import Math
 from .coords import InternalCoords
+from .geomlib import Geometry
 
-__all__ = ['Berny']
+__all__ = ['Berny', 'BernyParams']
 
 log = logging.getLogger(__name__)
 
-defaults = {
-    'gradientmax': 0.45e-3,
-    'gradientrms': 0.15e-3,
-    'stepmax': 1.8e-3,
-    'steprms': 1.2e-3,
-    'trust': 0.3,
-    'dihedral': True,
-    'superweakdih': False,
-}
-"""
-``gradientmax``, ``gradientrms``, ``stepmax``, ``steprms``
-    Convergence criteria in atomic units ("step" refers to the step in
-    internal coordinates, assuming radian units for angles).
 
-``trust``
-    Initial trust radius in atomic units. It is the maximum RMS of the
-    quadratic step (see below).
+@dataclass
+class BernyParams:
+    """Tunable parameters for :class:`Berny`.
 
-``dihedral``
-    Form dihedral angles.
+    Attributes:
+        gradientmax, gradientrms, stepmax, steprms: convergence criteria in
+            atomic units (``step`` refers to the step in internal coordinates,
+            assuming radian units for angles).
+        trust: initial trust radius in atomic units; the maximum RMS of the
+            quadratic step.
+        dihedral: whether to form dihedral angles.
+        superweakdih: whether to form dihedral angles containing two or more
+            noncovalent bonds.
+    """
 
-``superweakdih``
-    Form dihedral angles containing two or more noncovalent bonds.
-"""
+    gradientmax: float = 0.45e-3
+    gradientrms: float = 0.15e-3
+    stepmax: float = 1.8e-3
+    steprms: float = 1.2e-3
+    trust: float = 0.3
+    dihedral: bool = True
+    superweakdih: bool = False
 
 
-OptPoint = namedtuple('OptPoint', 'q E g')
+class OptPoint(NamedTuple):
+    q: np.ndarray
+    E: float | None
+    g: np.ndarray | None
+
+
+@dataclass
+class BernyState:
+    """Mutable optimizer state. Captured/restored via the ``debug``/``restart`` API."""
+
+    geom: Geometry
+    params: BernyParams
+    trust: float
+    coords: InternalCoords
+    H: np.ndarray
+    weights: np.ndarray
+    future: OptPoint
+    first: bool = True
+    interpolated: OptPoint | None = None
+    predicted: OptPoint | None = None
+    previous: OptPoint | None = None
+    best: OptPoint | None = None
 
 
 class BernyAdapter(logging.LoggerAdapter):
@@ -55,14 +78,13 @@ class Berny(Generator):
     """Generator that receives energy and gradients and yields the next geometry.
 
     Args:
-        geom (:class:`~berny.Geometry`): geometry to start with
-        debug (bool): if :data:`True`, the generator yields debug info on receiving
+        geom: geometry to start with
+        debug: if :data:`True`, the generator yields debug info on receiving
             the energy and gradients, otherwise it yields :data:`None`
-        restart (dict): start from a state saved from previous run
-            using ``debug=True``
-        maxsteps (int): abort after maximum number of steps
-        logger (:class:`logging.Logger`): alternative logger to use
-        params: parameters that override the :data:`~berny.berny.defaults`
+        restart: state captured from a previous run with ``debug=True``
+        maxsteps: abort after maximum number of steps
+        logger: alternative logger to use
+        params: parameter overrides — see :class:`BernyParams`
 
     The Berny object is to be used as follows::
 
@@ -72,35 +94,40 @@ class Berny(Generator):
             debug = optimizer.send((energy, gradients))
     """
 
-    class State:
-        pass
-
     def __init__(
-        self, geom, debug=False, restart=None, maxsteps=100, logger=None, **params
-    ):
+        self,
+        geom: Geometry,
+        debug: bool = False,
+        restart: dict[str, Any] | None = None,
+        maxsteps: int = 100,
+        logger: logging.Logger | None = None,
+        **params: Any,
+    ) -> None:
         self._debug = debug
         self._maxsteps = maxsteps
         self._converged = False
         self._n = 0
         self._log = BernyAdapter(logger or log, {'step': self._n})
-        s = self._state = Berny.State()
         if restart:
-            vars(s).update(restart)
+            self._state = BernyState(**restart)
             return
-        s.geom = geom
-        s.params = dict(chain(defaults.items(), params.items()))
-        s.trust = s.params['trust']
-        s.coords = InternalCoords(
-            s.geom, dihedral=s.params['dihedral'], superweakdih=s.params['superweakdih']
+        bparams = BernyParams(**params)
+        coords = InternalCoords(
+            geom, dihedral=bparams.dihedral, superweakdih=bparams.superweakdih
         )
-        s.H = s.coords.hessian_guess(s.geom)
-        s.weights = s.coords.weights(s.geom)
-        s.future = OptPoint(s.coords.eval_geom(s.geom), None, None)
-        s.first = True
-        for line in str(s.coords).split('\n'):
+        self._state = BernyState(
+            geom=geom,
+            params=bparams,
+            trust=bparams.trust,
+            coords=coords,
+            H=coords.hessian_guess(geom),
+            weights=coords.weights(geom),
+            future=OptPoint(coords.eval_geom(geom), None, None),
+        )
+        for line in str(coords).split('\n'):
             self._log.info(line)
 
-    def __next__(self):
+    def __next__(self) -> Geometry:
         assert self._n <= self._maxsteps
         if self._n >= self._maxsteps or self._converged:
             raise StopIteration
@@ -108,16 +135,18 @@ class Berny(Generator):
         return self._state.geom
 
     @property
-    def trust(self):
+    def trust(self) -> float:
         """Current trust radius."""
         return self._state.trust
 
     @property
-    def converged(self):
+    def converged(self) -> bool:
         """Whether the optimized has converged."""
         return self._converged
 
-    def send(self, energy_and_gradients):  # noqa: D102
+    def send(
+        self, energy_and_gradients: tuple[float, Any]
+    ) -> dict[str, Any] | None:  # noqa: D102
         self._log.extra['step'] = self._n
         log, s = self._log.info, self._state
         energy, gradients = energy_and_gradients
@@ -170,7 +199,8 @@ class Berny(Generator):
         if self._n == self._maxsteps:
             log('Maximum number of steps reached')
         if self._debug:
-            return vars(s).copy()
+            return {f.name: getattr(s, f.name) for f in fields(s)}
+        return None
 
     def throw(self, *args, **kwargs):  # noqa: D102
         return Generator.throw(self, *args, **kwargs)
@@ -255,18 +285,18 @@ def quadratic_step(g, H, w, trust, log=no_log):
     return dq, dE, on_sphere
 
 
-def is_converged(forces, step, on_sphere, params, log=no_log):
+def is_converged(forces, step, on_sphere, params: BernyParams, log=no_log) -> bool:
     criteria = [
-        ('Gradient RMS', Math.rms(forces), params['gradientrms']),
-        ('Gradient maximum', np.max(abs(forces)), params['gradientmax']),
+        ('Gradient RMS', Math.rms(forces), params.gradientrms),
+        ('Gradient maximum', np.max(abs(forces)), params.gradientmax),
     ]
     if on_sphere:
         criteria.append(('Minimization on sphere', False))
     else:
         criteria.extend(
             [
-                ('Step RMS', Math.rms(step), params['steprms']),
-                ('Step maximum', np.max(abs(step)), params['stepmax']),
+                ('Step RMS', Math.rms(step), params.steprms),
+                ('Step maximum', np.max(abs(step)), params.stepmax),
             ]
         )
     log('Convergence criteria:')

--- a/src/berny/berny.py
+++ b/src/berny/berny.py
@@ -46,9 +46,11 @@ class BernyParams:
 
 
 class OptPoint(NamedTuple):
+    # E and g are None for ``future``/``predicted`` points whose energy or
+    # gradient haven't been computed yet, and a float/ndarray otherwise.
     q: np.ndarray
-    E: float | None
-    g: np.ndarray | None
+    E: Any
+    g: Any
 
 
 @dataclass
@@ -70,8 +72,13 @@ class BernyState:
 
 
 class BernyAdapter(logging.LoggerAdapter):
+    step: int = 0
+
+    def __init__(self, logger: logging.Logger) -> None:
+        super().__init__(logger, {})
+
     def process(self, msg, kwargs):
-        return f"{self.extra['step']} {msg}", kwargs
+        return f'{self.step} {msg}', kwargs
 
 
 class Berny(Generator):
@@ -107,7 +114,7 @@ class Berny(Generator):
         self._maxsteps = maxsteps
         self._converged = False
         self._n = 0
-        self._log = BernyAdapter(logger or log, {'step': self._n})
+        self._log = BernyAdapter(logger or log)
         if restart:
             self._state = BernyState(**restart)
             return
@@ -144,10 +151,10 @@ class Berny(Generator):
         """Whether the optimized has converged."""
         return self._converged
 
-    def send(
+    def send(  # type: ignore[override]
         self, energy_and_gradients: tuple[float, Any]
     ) -> dict[str, Any] | None:  # noqa: D102
-        self._log.extra['step'] = self._n
+        self._log.step = self._n
         log, s = self._log.info, self._state
         energy, gradients = energy_and_gradients
         gradients = np.array(gradients)
@@ -156,6 +163,10 @@ class Berny(Generator):
         B_inv = B.T.dot(Math.pinv(np.dot(B, B.T), log=log))
         current = OptPoint(s.future.q, energy, dot(B_inv.T, gradients.reshape(-1)))
         if not s.first:
+            assert s.best is not None
+            assert s.previous is not None
+            assert s.predicted is not None
+            assert s.interpolated is not None
             s.H = update_hessian(
                 s.H, current.q - s.best.q, current.g - s.best.g, log=log
             )
@@ -190,7 +201,7 @@ class Berny(Generator):
         )
         s.future = OptPoint(q, None, None)
         s.previous = current
-        if s.first or current.E < s.best.E:
+        if s.first or (s.best is not None and current.E < s.best.E):
             s.best = current
         s.first = False
         self._converged = is_converged(
@@ -286,7 +297,7 @@ def quadratic_step(g, H, w, trust, log=no_log):
 
 
 def is_converged(forces, step, on_sphere, params: BernyParams, log=no_log) -> bool:
-    criteria = [
+    criteria: list[tuple] = [
         ('Gradient RMS', Math.rms(forces), params.gradientrms),
         ('Gradient maximum', np.max(abs(forces)), params.gradientmax),
     ]

--- a/src/berny/geomlib.py
+++ b/src/berny/geomlib.py
@@ -1,9 +1,13 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
 import os
+from collections.abc import Iterable, Iterator
 from io import StringIO
 from itertools import chain, groupby, product, repeat
+from typing import Any
 
 import numpy as np
 from numpy import pi
@@ -15,57 +19,69 @@ __all__ = ['Geometry', 'loads', 'readfile']
 
 
 class Geometry:
-    """
-    Represents a single molecule or a crystal.
-
-    :param list species: list of element symbols
-    :param list coords: list of atomic coordinates in angstroms (as 3-tuples)
-    :param list lattice: list of lattice vectors (:data:`None` for a moleucle)
+    """Represents a single molecule or a crystal.
 
     Iterating over a geometry yields 2-tuples of symbols and coordinates.
     :func:`len` returns the number of atoms in a geometry. The class supports
     :func:`format` with the same available formats as :meth:`dump`.
+
+    Args:
+        species: list of element symbols.
+        coords: atomic coordinates in angstroms, shape ``(N, 3)``.
+        lattice: lattice vectors, shape ``(3, 3)``, or :data:`None` for a
+            molecule.
     """
 
-    def __init__(self, species, coords, lattice=None):
+    def __init__(
+        self,
+        species: list[str],
+        coords: Any,
+        lattice: Any = None,
+    ) -> None:
         self.species = species
         self.coords = np.array(coords, dtype=float)
         self.lattice = np.array(lattice, dtype=float) if lattice is not None else None
 
     @classmethod
-    def from_atoms(cls, atoms, lattice=None, unit=1.0):
-        """Alternative contructor.
+    def from_atoms(
+        cls,
+        atoms: Iterable[tuple[str, Any]],
+        lattice: Any = None,
+        unit: float = 1.0,
+    ) -> Geometry:
+        """Alternative constructor.
 
-        :param list atoms: list of 2-tuples with an elemnt symbol and
-            a coordinate
-        :param float unit: value to multiple atomic coordiantes with
-        :param list lattice: list of lattice vectors (:data:`None` for a moleucle)
+        Args:
+            atoms: iterable of ``(element_symbol, coordinate)`` 2-tuples.
+            lattice: lattice vectors, or :data:`None` for a molecule.
+            unit: value to multiply atomic coordinates with.
         """
+        atoms = list(atoms)
         species = [sp for sp, _ in atoms]
         coords = [np.array(coord, dtype=float) * unit for _, coord in atoms]
         return cls(species, coords, lattice)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = repr(self.formula)
         if self.lattice is not None:
             s += ' in a lattice'
         return f'<{self.__class__.__name__} {s}>'
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, np.ndarray]]:
         yield from zip(self.species, self.coords)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.species)
 
     @property
-    def formula(self):
+    def formula(self) -> str:
         """Chemical formula of the molecule or a unit cell."""
         composition = sorted(
             (sp, len(list(g))) for sp, g in groupby(sorted(self.species))
         )
         return ''.join(f"{sp}{n if n > 1 else ''}" for sp, n in composition)
 
-    def __format__(self, fmt):
+    def __format__(self, fmt: str) -> str:
         """Return the geometry represented as a string, delegates to :meth:`dump`."""
         fp = StringIO()
         self.dump(fp, fmt)
@@ -73,7 +89,7 @@ class Geometry:
 
     dumps = __format__
 
-    def dump(self, f, fmt):
+    def dump(self, f: Any, fmt: str) -> None:
         """Save the geometry into a file.
 
         :param file f: file object
@@ -105,7 +121,7 @@ class Geometry:
         else:
             raise ValueError(f'Unknown format: {fmt!r}')
 
-    def copy(self):
+    def copy(self) -> Geometry:
         """Make a copy of the geometry."""
         return Geometry(
             list(self.species),
@@ -113,11 +129,11 @@ class Geometry:
             self.lattice.copy() if self.lattice is not None else None,
         )
 
-    def write(self, filename):
-        """
-        Write the geometry into a file, delegates to :meth:`dump`.
+    def write(self, filename: str) -> None:
+        """Write the geometry into a file, delegates to :meth:`dump`.
 
-        :param str filename: path that will be overwritten
+        Args:
+            filename: path that will be overwritten.
         """
         ext = os.path.splitext(filename)[1]
         if ext == '.xyz':
@@ -253,7 +269,7 @@ class Geometry:
         return np.sum(A - B, 0)
 
 
-def load(fp, fmt):
+def load(fp: Any, fmt: str) -> Geometry:
     """
     Read a geometry from a file object.
 
@@ -298,22 +314,23 @@ def load(fp, fmt):
             return Geometry(species, coords)
 
 
-def loads(s, fmt):
-    """
-    Read a geometry from a string, delegates to :func:`load`.
+def loads(s: str, fmt: str) -> Geometry:
+    """Read a geometry from a string, delegates to :func:`load`.
 
-    :param str s: string with geometry
+    Args:
+        s: string with geometry.
+        fmt: geometry format (see :func:`load`).
     """
     fp = StringIO(s)
     return load(fp, fmt)
 
 
-def readfile(path, fmt=None):
-    """
-    Read a geometry from a file path, delegates to :func:`load`.
+def readfile(path: str, fmt: str | None = None) -> Geometry:
+    """Read a geometry from a file path, delegates to :func:`load`.
 
-    :param str path: path to a geometry file
-    :param str fmt: if not given, the format is given from the file extension
+    Args:
+        path: path to a geometry file.
+        fmt: format; if not given, derived from the file extension.
     """
     if not fmt:
         ext = os.path.splitext(path)[1]

--- a/src/berny/geomlib.py
+++ b/src/berny/geomlib.py
@@ -270,14 +270,11 @@ class Geometry:
 
 
 def load(fp: Any, fmt: str) -> Geometry:
-    """
-    Read a geometry from a file object.
+    """Read a geometry from a file object.
 
-    :param file fp: file object
-    :param str fmt: the format of the geometry file, can be one of ``"xyz"``,
-        ``"aims"``
-
-    Returns :class:`~berny.Geometry`.
+    Args:
+        fp: file object.
+        fmt: geometry format, one of ``"xyz"`` or ``"aims"``.
     """
     if fmt == 'xyz':
         n = int(fp.readline())
@@ -310,8 +307,8 @@ def load(fp: Any, fmt: str) -> Geometry:
         if lattice:
             assert len(lattice) == 3
             return Geometry(species, coords, lattice)
-        else:
-            return Geometry(species, coords)
+        return Geometry(species, coords)
+    raise ValueError(f'Unknown format: {fmt!r}')
 
 
 def loads(s: str, fmt: str) -> Geometry:
@@ -336,7 +333,9 @@ def readfile(path: str, fmt: str | None = None) -> Geometry:
         ext = os.path.splitext(path)[1]
         if ext == '.xyz':
             fmt = 'xyz'
-        if ext == '.aims' or os.path.basename(path) == 'geometry.in':
+        elif ext == '.aims' or os.path.basename(path) == 'geometry.in':
             fmt = 'aims'
+        else:
+            raise ValueError(f'Cannot infer format from path {path!r}')
     with open(path) as f:
         return load(f, fmt)

--- a/src/berny/optimize.py
+++ b/src/berny/optimize.py
@@ -3,14 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from collections.abc import Generator
+from typing import Any
 
 from .geomlib import Geometry
 
 
 def optimize(
-    optimizer: Generator,
-    solver: Generator,
+    optimizer: Any,
+    solver: Any,
     trajectory: str | None = None,
 ) -> Geometry:
     """Optimize a geometry with respect to a solver.

--- a/src/berny/optimize.py
+++ b/src/berny/optimize.py
@@ -1,23 +1,30 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+from collections.abc import Generator
+
+from .geomlib import Geometry
 
 
-def optimize(optimizer, solver, trajectory=None):
+def optimize(
+    optimizer: Generator,
+    solver: Generator,
+    trajectory: str | None = None,
+) -> Geometry:
     """Optimize a geometry with respect to a solver.
 
     Args:
-        optimizer (:class:`~collections.abc.Generator`): Optimizer object with
-            the same generator interface as :class:`~berny.Berny`
-        solver (:class:`~collections.abc.Generator`): unprimed generator that
-            receives geometry as a 2-tuple of a list of 2-tuples of the atom
-            symbol and coordinate (as a 3-tuple), and of a list of lattice
-            vectors (or :data:`None` if molecule), and yields the energy and
-            gradients (as a :math:`N`-by-3 matrix or :math:`(N+3)`-by-3 matrix
-            in case of a crystal geometry).
+        optimizer: optimizer with the generator interface of :class:`~berny.Berny`
+        solver: unprimed generator that receives geometry as a 2-tuple of a
+            list of 2-tuples of the atom symbol and coordinate (as a 3-tuple),
+            and of a list of lattice vectors (or :data:`None` if molecule), and
+            yields the energy and gradients (as a :math:`N`-by-3 matrix or
+            :math:`(N+3)`-by-3 matrix in case of a crystal geometry).
 
             See :class:`~berny.solvers.MopacSolver` for an example.
-        trajectory (str): filename for the XYZ trajectory
+        trajectory: filename for the XYZ trajectory
 
     Returns:
         The optimized geometry.
@@ -30,15 +37,15 @@ def optimize(optimizer, solver, trajectory=None):
             optimizer.send((energy, gradients))
     """
     if trajectory:
-        trajectory = open(trajectory, 'w')
+        traj_fp = open(trajectory, 'w')
     try:
         next(solver)
         for geom in optimizer:
             energy, gradients = solver.send((list(geom), geom.lattice))
             if trajectory:
-                geom.dump(trajectory, 'xyz')
+                geom.dump(traj_fp, 'xyz')
             optimizer.send((energy, gradients))
     finally:
         if trajectory:
-            trajectory.close()
+            traj_fp.close()
     return geom

--- a/tests/test_berny.py
+++ b/tests/test_berny.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+from berny import Berny, BernyParams, Geometry
+
+
+def water():
+    return Geometry(
+        ['O', 'H', 'H'], [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]]
+    )
+
+
+def test_berny_params_defaults():
+    p = BernyParams()
+    assert p.gradientmax == 0.45e-3
+    assert p.trust == 0.3
+    assert p.dihedral is True
+
+
+def test_berny_param_override():
+    b = Berny(water(), trust=0.5, gradientrms=1e-4)
+    assert b.trust == 0.5
+    assert b._state.params.gradientrms == 1e-4
+    # Untouched defaults still come from BernyParams.
+    assert b._state.params.gradientmax == 0.45e-3
+
+
+def test_berny_unknown_param_rejected():
+    # BernyParams has fixed fields; typos no longer silently end up in a
+    # params dict that nobody reads.
+    try:
+        Berny(water(), trust=0.5, gradeintrms=1e-4)
+    except TypeError as e:
+        assert 'gradeintrms' in str(e)
+    else:
+        raise AssertionError('expected TypeError for unknown param')
+
+
+def test_berny_debug_restart_roundtrip():
+    geom = water()
+    b = Berny(geom, debug=True)
+    next(b)
+    state = b.send((0.0, np.zeros((3, 3))))
+    assert isinstance(state, dict)
+    assert 'geom' in state and 'params' in state
+    b2 = Berny(geom, restart=state)
+    assert b2.trust == b._state.trust


### PR DESCRIPTION
## Summary

Step 3 of the codebase review (after #48 and #50). Three related changes that pay off the biggest readability debt:

### `BernyParams` dataclass replaces the mutable `defaults` dict

Before: a module-level `defaults` dict, freely mutable by anyone with an import, with parameter names known only by reading the source.

After: a `@dataclass BernyParams` with typed fields and a single source of truth. The class is exported from the package, so IDE autocomplete shows the available parameters. `Berny(geom, gradeintrms=1e-4)` now raises `TypeError` instead of silently dropping the typo into a dict nobody reads.

### `BernyState` dataclass replaces the empty `class State: pass`

Before: `s = Berny.State()` with attributes set via assignment — no schema, no IDE help, typos silently create new attributes.

After: a `@dataclass BernyState` with all 12 fields typed. The debug/restart protocol is preserved: `send(...)` with `debug=True` returns a shallow field dict, and `Berny(geom, restart=that_dict)` reconstructs the state via the dataclass constructor.

### Type hints on the public API

`Berny.__init__/__next__/send/converged/trust`, `optimize`, `Geometry.__init__/from_atoms/__iter__/copy/dump/write`, and `load/loads/readfile`. Uses `from __future__ import annotations` for forward references (Py3.9 floor).

### Side fixes picked up along the way

- `Geometry.from_atoms` now materialises `atoms` into a list before iterating it twice, so a generator argument works.
- `optimize` no longer rebinds the `trajectory: str | None` parameter to a file object; a separate `traj_fp` local holds the open file.
- `doc/api.rst` swaps the dropped `defaults` autodata for `BernyParams`.

### Breaking changes (deliberate, called out in the review)

- `berny.berny.defaults` is gone. Anyone reading it directly would have been one bug away from mutating shared state for the rest of the process.
- Unknown kwargs to `Berny()` raise `TypeError`. This catches typos that previously did nothing.

### Verification

- `pytest tests/` → 15 passed (added 4 unit tests covering: BernyParams defaults, param override, unknown-param rejection, debug→restart round-trip).
- `flake8` (with `flake8-bugbear` enabled — caught us last time), `black --check`, `isort --check`, `pydocstyle` all clean.

## Test plan

- [x] `pytest tests/` passes locally
- [x] `flake8` (with bugbear) clean
- [x] `black --check`, `isort --check`, `pydocstyle` clean
- [x] Manual smoke test of constructor signature, restart round-trip, param override
- [x] CI green on push

https://claude.ai/code/session_01AjX8xB3GE1waHpRW68VSqt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjX8xB3GE1waHpRW68VSqt)_