### PR TITLE
Add scripts/check.sh to mirror CI locally

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # Project conventions
 
+## Pre-push checks
+
+Before `git push`, run `scripts/check.sh`. It runs the same lint and test
+commands CI runs (`flake8`, `black --check`, `isort --check`, `pydocstyle src`,
+`pytest`) against the current Python, so most CI failures are catchable
+locally without waiting for the 5-version matrix.
+
 ## CHANGELOG
 
 `CHANGELOG.md` is reserved for important user-facing changes — new features,

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Run the same checks CI runs (lint + tests) against the current Python.
+# Mirrors .github/workflows/lint.yaml and .github/workflows/tests.yaml.
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+run() {
+    local name=$1
+    shift
+    echo "=== $name ==="
+    if ! "$@"; then
+        fail=1
+        echo "--- $name FAILED ---"
+    fi
+}
+
+run flake8     flake8
+run black      black . --check
+run isort      isort . --check
+run pydocstyle pydocstyle src
+run pytest     python -m pytest -q
+
+if [ "$fail" -ne 0 ]; then
+    echo "One or more checks failed."
+    exit 1
+fi
+echo "All checks passed."


### PR DESCRIPTION
## Summary
- Add `scripts/check.sh` running the same checks CI runs (`flake8`, `black --check`, `isort --check`, `pydocstyle src`, `pytest`) against the current Python.
- Add a "Pre-push checks" note to `CLAUDE.md` directing the agent to run it before `git push`.

Shortens the feedback loop: most CI failures become catchable in ~5s locally without waiting on the 5-version test matrix. The only thing CI catches that this misses is Python-version-specific breakage.

`pytest` is invoked as `python -m pytest` because the bare `pytest` on the web sandbox resolves to a uv-managed tool env that doesn't see project deps.

## Test plan
- [x] `./scripts/check.sh` exits 0 on a clean tree (all 5 checks pass in ~5s).
- [x] Existing CI workflows still pass on this PR.

https://claude.ai/code/session_01Mg5RwKw5jDyPqHe4Etg49U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mg5RwKw5jDyPqHe4Etg49U)_