### PR TITLE
Expand test coverage from 77% to 95%

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,16 @@
+import json
+import pickle
+import sys
+from argparse import Namespace
 from io import StringIO
 
+import pytest
+
 from berny import Berny
-from berny.cli import handler
+from berny.cli import berny_unpickled, driver, get_berny, handler, init, main
 from berny.geomlib import Geometry
+
+WATER_XYZ = '3\n\nO 0 0 0\nH 0.96 0 0\nH 0 0.96 0\n'
 
 
 def test_handler_converges_returns_none():
@@ -19,3 +27,133 @@ def test_handler_converges_returns_none():
     result = handler(berny, f)
     assert result is None
     assert berny.converged
+
+
+def test_handler_returns_geometry_when_not_converged(monkeypatch):
+    # If the optimizer isn't done, handler should hand back the next
+    # geometry — drive a single non-converging step.
+    geom = Geometry(
+        ['O', 'H', 'H'], [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0]]
+    )
+    berny = Berny(geom)
+    next(berny)
+    f = StringIO('0.0\n1 0 0\n-1 0 0\n0 1 0\n')
+    result = handler(berny, f)
+    assert isinstance(result, Geometry)
+    assert not berny.converged
+
+
+def test_get_berny_reads_stdin_xyz(monkeypatch):
+    monkeypatch.setattr(sys, 'stdin', StringIO(WATER_XYZ))
+    args = Namespace(format='xyz', paramfile=None)
+    berny = get_berny(args)
+    # The function primes the generator with one `next` call already.
+    assert berny._n == 1
+
+
+def test_get_berny_reads_paramfile(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, 'stdin', StringIO(WATER_XYZ))
+    paramfile = tmp_path / 'params.json'
+    paramfile.write_text(json.dumps({'maxsteps': 5}))
+    args = Namespace(format='xyz', paramfile=str(paramfile))
+    berny = get_berny(args)
+    assert berny._maxsteps == 5
+
+
+def test_init_writes_pickle_in_cwd(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, 'stdin', StringIO(WATER_XYZ))
+    args = Namespace(format='xyz', paramfile=None)
+    init(args)
+    pkl = tmp_path / 'berny.pickle'
+    assert pkl.exists()
+    with open(pkl, 'rb') as f:
+        restored = pickle.load(f)
+    assert isinstance(restored, Berny)
+    assert restored.geom_format == 'xyz'
+
+
+def test_berny_unpickled_round_trips_state(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    # Prime a Berny and pickle it manually so we can verify the context
+    # manager loads it, lets us mutate it, and re-pickles the mutation.
+    geom = Geometry(
+        ['O', 'H', 'H'], [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]]
+    )
+    berny = Berny(geom)
+    next(berny)
+    with open('berny.pickle', 'wb') as f:
+        pickle.dump(berny, f)
+    with berny_unpickled() as b:
+        b.geom_format = 'aims'  # arbitrary mutation
+    with open('berny.pickle', 'rb') as f:
+        restored = pickle.load(f)
+    assert restored.geom_format == 'aims'
+
+
+def test_driver_missing_pickle_exits_with_error(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, 'stdin', StringIO('0.0\n0 0 0\n0 0 0\n0 0 0\n'))
+    with pytest.raises(SystemExit) as exc:
+        driver()
+    assert exc.value.code == 1
+    assert 'No pickled berny' in capsys.readouterr().err
+
+
+def test_driver_unconverged_writes_geom_and_exits_10(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    geom = Geometry(
+        ['O', 'H', 'H'], [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.0, 0.5, 0.0]]
+    )
+    berny = Berny(geom)
+    berny.geom_format = 'xyz'
+    next(berny)
+    with open('berny.pickle', 'wb') as f:
+        pickle.dump(berny, f)
+    monkeypatch.setattr(sys, 'stdin', StringIO('0.0\n1 0 0\n-1 0 0\n0 1 0\n'))
+    with pytest.raises(SystemExit) as exc:
+        driver()
+    assert exc.value.code == 10
+    out = capsys.readouterr().out
+    assert out.splitlines()[0].strip().isdigit()  # XYZ atom count line
+
+
+def test_driver_converged_exits_zero(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    geom = Geometry(
+        ['O', 'H', 'H'], [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]]
+    )
+    berny = Berny(geom)
+    berny.geom_format = 'xyz'
+    next(berny)
+    with open('berny.pickle', 'wb') as f:
+        pickle.dump(berny, f)
+    monkeypatch.setattr(sys, 'stdin', StringIO('0.0\n0 0 0\n0 0 0\n0 0 0\n'))
+    with pytest.raises(SystemExit) as exc:
+        driver()
+    assert exc.value.code == 0
+
+
+def test_main_init_dispatches(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, 'argv', ['berny', '--init'])
+    monkeypatch.setattr(sys, 'stdin', StringIO(WATER_XYZ))
+    main()
+    assert (tmp_path / 'berny.pickle').exists()
+
+
+def test_main_driver_dispatches(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    geom = Geometry(
+        ['O', 'H', 'H'], [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]]
+    )
+    berny = Berny(geom)
+    berny.geom_format = 'xyz'
+    next(berny)
+    with open('berny.pickle', 'wb') as f:
+        pickle.dump(berny, f)
+    monkeypatch.setattr(sys, 'argv', ['berny'])
+    monkeypatch.setattr(sys, 'stdin', StringIO('0.0\n0 0 0\n0 0 0\n0 0 0\n'))
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 0

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from berny.coords import Angle, Bond, Dihedral, InternalCoords, angstrom
@@ -76,3 +77,125 @@ def test_get_property_missing_data_raises_keyerror():
             get_property(999, 'covalent_radius')
     finally:
         del species_data['Zz']
+
+
+def test_get_property_unknown_symbol_raises():
+    with pytest.raises(KeyError, match="'Xx'"):
+        get_property('Xx', 'mass')
+
+
+def test_get_property_unknown_number_raises():
+    with pytest.raises(KeyError, match='9999'):
+        get_property(9999, 'mass')
+
+
+def test_get_property_known_species_lookup_by_number():
+    # Hydrogen is element 1 — exercises the int-lookup branch.
+    assert get_property(1, 'symbol') == 'H'
+
+
+def test_internal_coord_repr_with_connectivity():
+    # __repr__ requires the `weak` attribute, which is only populated when
+    # the coord is constructed with a connectivity matrix `C`.
+    C = np.ones((4, 4), dtype=bool)
+    assert repr(Bond(0, 1, C=C)).startswith('Bond(') and 'weak=0' in repr(
+        Bond(0, 1, C=C)
+    )
+    assert repr(Angle(0, 1, 2, C=C)).startswith('Angle(')
+    assert repr(Dihedral(0, 1, 2, 3, C=C)).startswith('Dihedral(')
+
+
+def test_angle_eval_clamps_collinear_atoms():
+    # Three colinear atoms — the dot product would round to slightly above
+    # 1, triggering the upper clip; arccos must still return 0 or π.
+    a = Angle(0, 1, 2)
+    coords = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    # Both extend the same way → 0 rad after clamp.
+    assert a.eval(coords) == pytest.approx(0.0)
+    # Opposite direction → π rad.
+    coords[2] = [-2.0, 0.0, 0.0]
+    assert a.eval(coords) == pytest.approx(np.pi)
+
+
+def test_angle_grad_near_pi():
+    # A nearly-π angle hits the "phi > π − 1e-6" gradient branch.
+    a = Angle(0, 1, 2)
+    coords = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [-1.0, 1e-8, 0.0]])
+    phi, grad = a.eval(coords, grad=True)
+    assert phi == pytest.approx(np.pi, abs=1e-3)
+    assert len(grad) == 3
+    assert all(np.all(np.isfinite(g)) for g in grad)
+
+
+def test_dihedral_grad_near_zero():
+    # Planar geometry → phi ≈ 0 → hits the small-phi gradient branch.
+    d = Dihedral(0, 1, 2, 3)
+    coords = np.array(
+        [
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ]
+    )
+    phi, grad = d.eval(coords, grad=True)
+    assert abs(phi) < 1e-6
+    assert len(grad) == 4
+    assert all(np.all(np.isfinite(g)) for g in grad)
+
+
+def test_dihedral_grad_near_pi():
+    # cis vs trans: trans → phi ≈ π.
+    d = Dihedral(0, 1, 2, 3)
+    coords = np.array(
+        [
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, -1.0, 0.0],
+        ]
+    )
+    phi, grad = d.eval(coords, grad=True)
+    assert abs(abs(phi) - np.pi) < 1e-6
+    assert len(grad) == 4
+    assert all(np.all(np.isfinite(g)) for g in grad)
+
+
+def test_internal_coords_repr_and_str_describe_counts():
+    geom = Geometry(
+        ['O', 'H', 'H'],
+        [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]],
+    )
+    coords = InternalCoords(geom)
+    r = repr(coords)
+    assert r.startswith('<InternalCoords')
+    assert 'bonds' in r and 'angles' in r and 'dihedrals' in r
+    s = str(coords)
+    assert 'Internal coordinates' in s
+    assert 'Number of fragments' in s
+
+
+def test_internal_coords_without_dihedrals():
+    # `dihedral=False` skips the get_dihedrals loop — covers the missing
+    # branch around InternalCoords.__init__.
+    geom = Geometry(
+        ['O', 'H', 'H', 'H'],
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]],
+    )
+    coords = InternalCoords(geom, dihedral=False)
+    assert coords.dihedrals == []
+    assert len(coords.bonds) > 0
+
+
+def test_internal_coords_on_crystal_prunes_via_reduce():
+    # A small primitive H₂ crystal exercises the `_reduce` path that
+    # InternalCoords runs only when geom.lattice is not None.
+    geom = Geometry(
+        ['H', 'H'],
+        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.74]],
+        lattice=[[5.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 5.0]],
+    )
+    coords = InternalCoords(geom)
+    # Reduce keeps at least one bond between the two atoms.
+    assert len(coords.bonds) >= 1
+    assert len(coords) > 0

--- a/tests/test_geomlib.py
+++ b/tests/test_geomlib.py
@@ -1,6 +1,9 @@
-import numpy as np
+from pathlib import Path
 
-from berny.geomlib import Geometry, loads
+import numpy as np
+import pytest
+
+from berny.geomlib import Geometry, load, loads, readfile
 
 
 def test_aims_round_trip_molecule():
@@ -20,3 +23,232 @@ def test_aims_round_trip_crystal():
     assert g2.lattice is not None
     assert np.allclose(g2.lattice, g.lattice)
     assert np.allclose(g2.coords, g.coords)
+
+
+def test_xyz_round_trip():
+    g = Geometry(['O', 'H', 'H'], [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]])
+    g2 = loads(format(g, 'xyz'), 'xyz')
+    assert g2.species == g.species
+    assert np.allclose(g2.coords, g.coords)
+    assert g2.lattice is None
+
+
+def test_mopac_dump_contains_atoms_with_flags():
+    # mopac is dump-only (load doesn't accept it). Just check the output
+    # has one line per atom with the trailing `1` optimization flags.
+    g = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
+    out = format(g, 'mopac').splitlines()
+    assert out[0].startswith('*')
+    assert len(out) == 1 + len(g)
+    # Each line: symbol x 1 y 1 z 1
+    assert out[1].split()[0] == 'H'
+    assert out[1].split()[-1] == '1'
+
+
+def test_dump_empty_format_uses_repr():
+    g = Geometry(['H'], [[0.0, 0.0, 0.0]])
+    assert format(g, '') == repr(g)
+
+
+def test_dump_unknown_format_raises():
+    g = Geometry(['H'], [[0.0, 0.0, 0.0]])
+    with pytest.raises(ValueError, match='Unknown format'):
+        format(g, 'pdb')
+
+
+def test_load_unknown_format_raises():
+    with pytest.raises(ValueError, match='Unknown format'):
+        loads('', 'pdb')
+
+
+def test_repr_distinguishes_molecule_and_crystal():
+    mol = Geometry(['H'], [[0.0, 0.0, 0.0]])
+    crys = Geometry(['H'], [[0.0, 0.0, 0.0]], lattice=[[5, 0, 0], [0, 5, 0], [0, 0, 5]])
+    assert 'in a lattice' not in repr(mol)
+    assert 'in a lattice' in repr(crys)
+
+
+def test_formula_groups_and_orders_species():
+    g = Geometry(
+        ['H', 'C', 'H', 'O', 'H', 'H'],
+        [[i, 0.0, 0.0] for i in range(6)],
+    )
+    # Sorted alphabetically; counts collapsed; singletons omit the number.
+    assert g.formula == 'CH4O'
+
+
+def test_from_atoms_applies_unit():
+    g = Geometry.from_atoms([('H', [1.0, 0.0, 0.0])], unit=2.0)
+    assert np.allclose(g.coords, [[2.0, 0.0, 0.0]])
+
+
+def test_copy_is_independent():
+    lattice = [[5, 0, 0], [0, 5, 0], [0, 0, 5]]
+    g = Geometry(['H', 'H'], [[0, 0, 0], [0, 0, 0.5]], lattice=lattice)
+    g2 = g.copy()
+    g2.coords[0, 0] = 99.0
+    g2.lattice[0, 0] = 99.0
+    g2.species[0] = 'He'
+    assert g.coords[0, 0] == 0.0
+    assert g.lattice[0, 0] == 5.0
+    assert g.species[0] == 'H'
+
+
+def test_write_dispatches_by_extension(tmp_path):
+    g = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
+    xyz = tmp_path / 'mol.xyz'
+    aims = tmp_path / 'mol.aims'
+    geom_in = tmp_path / 'geometry.in'
+    mop = tmp_path / 'mol.mopac'
+    g.write(str(xyz))
+    g.write(str(aims))
+    g.write(str(geom_in))
+    g.write(str(mop))
+    # Round-trip the two formats that can be loaded.
+    assert loads(xyz.read_text(), 'xyz').species == g.species
+    assert loads(aims.read_text(), 'aims').species == g.species
+    assert loads(geom_in.read_text(), 'aims').species == g.species
+    # mopac is dump-only — just check it produced something starting with `*`.
+    assert mop.read_text().startswith('*')
+
+
+def test_write_unknown_extension_raises(tmp_path):
+    g = Geometry(['H'], [[0.0, 0.0, 0.0]])
+    with pytest.raises(ValueError, match='Unknown file extension'):
+        g.write(str(tmp_path / 'mol.pdb'))
+
+
+def test_readfile_infers_format_from_extension(tmp_path):
+    g = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
+    xyz = tmp_path / 'mol.xyz'
+    aims = tmp_path / 'mol.aims'
+    geom_in = tmp_path / 'geometry.in'
+    g.write(str(xyz))
+    g.write(str(aims))
+    g.write(str(geom_in))
+    assert readfile(str(xyz)).species == g.species
+    assert readfile(str(aims)).species == g.species
+    assert readfile(str(geom_in)).species == g.species
+
+
+def test_readfile_explicit_format_overrides_extension(tmp_path):
+    g = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
+    path = tmp_path / 'mol.weird'
+    path.write_text(format(g, 'xyz'))
+    assert readfile(str(path), fmt='xyz').species == g.species
+
+
+def test_readfile_unknown_extension_raises(tmp_path):
+    path = tmp_path / 'mol.pdb'
+    path.write_text('')
+    with pytest.raises(ValueError, match='Cannot infer format'):
+        readfile(str(path))
+
+
+def test_load_from_file_object(tmp_path):
+    g = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
+    path = tmp_path / 'mol.xyz'
+    path.write_text(format(g, 'xyz'))
+    with open(path) as f:
+        loaded = load(f, 'xyz')
+    assert loaded.species == g.species
+    assert np.allclose(loaded.coords, g.coords)
+
+
+def test_bondmatrix_water():
+    # O-H bonds present; H-H not bonded.
+    g = Geometry(['O', 'H', 'H'], [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]])
+    B = g.bondmatrix()
+    assert B[0, 1] and B[1, 0]
+    assert B[0, 2] and B[2, 0]
+    assert not B[1, 2] and not B[2, 1]
+
+
+def test_dist_and_dist_diff():
+    g = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [3.0, 4.0, 0.0]])
+    d, diff = g.dist_diff()
+    assert d[0, 1] == pytest.approx(5.0)
+    assert np.allclose(diff[0, 1], [-3.0, -4.0, 0.0])
+    # diag is set to inf to avoid self-counting in bond detection.
+    assert np.isinf(d[0, 0])
+    assert g.dist()[0, 1] == pytest.approx(5.0)
+
+
+def test_dist_diff_between_two_geoms():
+    g1 = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    g2 = Geometry(['H', 'H', 'H'], [[2.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 1.0]])
+    d, diff = g1.dist_diff(g2)
+    assert d[0, 1] == pytest.approx(5.0)
+    assert d[1, 0] == pytest.approx(1.0)
+    assert np.allclose(diff[0, 1], [0.0, -5.0, 0.0])
+
+
+def test_masses_cms_and_inertia_for_diatomic():
+    # Two equal H atoms along z: CMS at the midpoint, moment of inertia is
+    # m*r^2 about the two perpendicular axes and 0 about the bond axis.
+    d = 1.0
+    g = Geometry(['H', 'H'], [[0.0, 0.0, -d / 2], [0.0, 0.0, d / 2]])
+    m = g.masses[0]
+    assert np.allclose(g.masses, [m, m])
+    assert np.allclose(g.cms, [0.0, 0.0, 0.0])
+    I = g.inertia
+    # Symmetric, so off-diagonals vanish.
+    assert np.allclose(I - np.diag(np.diag(I)), 0)
+    assert I[0, 0] == pytest.approx(2 * m * (d / 2) ** 2)
+    assert I[1, 1] == pytest.approx(2 * m * (d / 2) ** 2)
+    assert I[2, 2] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_supercell_on_molecule_returns_copy():
+    g = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
+    sc = g.supercell()
+    assert sc.lattice is None
+    assert sc.species == g.species
+    assert np.allclose(sc.coords, g.coords)
+    # Independent copy.
+    sc.coords[0, 0] = 99.0
+    assert g.coords[0, 0] == 0.0
+
+
+def test_supercell_default_ranges_expands_unit_cell():
+    a = 3.0
+    lattice = [[a, 0, 0], [0, a, 0], [0, 0, a]]
+    g = Geometry(['H'], [[0.0, 0.0, 0.0]], lattice=lattice)
+    sc = g.supercell()  # ranges = ((-1, 1)…) → shifts in [-1, 0, 1] per axis.
+    assert len(sc) == 27
+    # Lattice scales by (b − a) = 2, not by the number of shifts.
+    assert np.allclose(sc.lattice, np.array(lattice) * 2)
+
+
+def test_supercell_cutoff_uses_super_circum():
+    a = 2.0
+    lattice = [[a, 0, 0], [0, a, 0], [0, 0, a]]
+    g = Geometry(['H'], [[0.0, 0.0, 0.0]], lattice=lattice)
+    # super_circum picks the smallest cell whose layer-sep ≥ cutoff. With
+    # a=2 and cutoff=3 the heuristic adds at least one layer on each side.
+    sc = g.supercell(cutoff=3.0)
+    assert sc.lattice is not None
+    assert len(sc) > 1
+
+
+def test_super_circum_on_molecule_returns_none():
+    g = Geometry(['H'], [[0.0, 0.0, 0.0]])
+    assert g.super_circum(5.0) is None
+
+
+def test_super_circum_cubic_lattice():
+    a = 2.0
+    g = Geometry(['H'], [[0.0, 0.0, 0.0]], lattice=[[a, 0, 0], [0, a, 0], [0, 0, a]])
+    # layer separation = a, so ceil(r/a + 0.5) for each axis.
+    assert np.array_equal(g.super_circum(3.0), [2, 2, 2])
+
+
+XYZ_DIR = Path(__file__).parent
+
+
+def test_readfile_loads_bundled_xyz():
+    # Sanity-check against an existing fixture so we'd notice if the loader
+    # ever broke on real-world input.
+    g = readfile(str(XYZ_DIR / 'water.xyz'))
+    assert g.species == ['O', 'H', 'H']
+    assert len(g) == 3

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -45,6 +45,17 @@ class TestPinv:
         P = Math.pinv(A) @ A
         assert np.linalg.matrix_rank(P, tol=1e-6) == 2
 
+    def test_warns_on_modest_singular_value_gap(self):
+        # A gap above the truncation threshold (1e3) but below the "safe"
+        # threshold (1e8) triggers a diagnostic log message.
+        Q = np.linalg.qr(np.random.default_rng(2).standard_normal((3, 3)))[0]
+        # gaps = [1.0/1e-5, 1e-5/1e-6] = [1e5, 10] → first gap is in the
+        # warn band.
+        A = Q @ np.diag([1.0, 1e-5, 1e-6]) @ Q.T
+        messages = []
+        Math.pinv(A, log=messages.append)
+        assert any('Pseudoinverse gap' in m for m in messages)
+
 
 class TestCross:
     def test_matches_numpy(self):

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -42,3 +42,20 @@ def test_optimize(mopac, test_case):
     assert (
         berny._n <= n_ref + 2
     ), f'converged in {berny._n} steps, more than the {n_ref} + 2 band'
+
+
+def test_optimize_writes_trajectory(mopac, tmp_path):
+    geom, _ = water()
+    berny = Berny(geom)
+    traj = tmp_path / 'traj.xyz'
+    optimize(berny, mopac, trajectory=str(traj))
+    assert berny.converged
+    # One XYZ frame per optimizer step. Each frame is atom_count + comment +
+    # N atom lines = N + 2 lines.
+    lines = traj.read_text().splitlines()
+    n = len(geom)
+    assert len(lines) % (n + 2) == 0
+    n_frames = len(lines) // (n + 2)
+    assert n_frames == berny._n
+    for i in range(n_frames):
+        assert lines[i * (n + 2)].strip() == str(n)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,6 +1,8 @@
+import numpy as np
 import pytest
 
-from berny.solvers import _mopac_keyword_line
+from berny.coords import angstrom
+from berny.solvers import GenericSolver, _diff5, _mopac_keyword_line
 
 
 def test_mopac_neutral_singlet():
@@ -22,3 +24,97 @@ def test_mopac_doublet_cation():
 def test_mopac_unsupported_multiplicity():
     with pytest.raises(ValueError, match='unsupported MOPAC multiplicity'):
         _mopac_keyword_line('PM7', 0, 99)
+
+
+def test_diff5_recovers_derivative_of_cubic():
+    # 5-point stencil is exact (to numerical noise) for polynomials up to
+    # degree 4, so x^3 derivative should come out spot-on at any x0.
+    x0, delta = 1.7, 1e-3
+    samples = {step: (x0 + step * delta) ** 3 for step in (-2, -1, 1, 2)}
+    assert _diff5(samples, delta) == pytest.approx(3 * x0**2, rel=1e-6)
+
+
+def _quadratic_factory(target):
+    target = np.asarray(target, dtype=float)
+
+    def f(atoms, lattice):
+        coords = np.array([c for _, c in atoms])
+        return float(np.sum((coords - target) ** 2))
+
+    return f
+
+
+def test_generic_solver_matches_analytical_gradient():
+    target = np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    f = _quadratic_factory(target)
+
+    solver = GenericSolver(f)
+    next(solver)
+    atoms = [
+        ('H', np.array([0.1, 0.0, 0.0])),
+        ('H', np.array([0.0, 1.2, 0.0])),
+    ]
+    energy, gradients = solver.send((atoms, None))
+
+    coords = np.array([c for _, c in atoms])
+    assert energy == pytest.approx(float(np.sum((coords - target) ** 2)))
+    # Analytic ∂E/∂x_i = 2(x_i − target_i); GenericSolver divides the
+    # finite-difference gradient by `angstrom` to convert per-Å → per-bohr.
+    expected = 2 * (coords - target) / angstrom
+    np.testing.assert_allclose(gradients, expected, atol=1e-6)
+
+
+def test_generic_solver_handles_lattice():
+    # Energy depends on both atoms and lattice; the solver must finite-
+    # difference both blocks and stack them ((N+3, 3) gradient).
+    def f(atoms, lattice):
+        coords = np.array([c for _, c in atoms])
+        return float(np.sum(coords**2) + np.sum(lattice**2))
+
+    solver = GenericSolver(f)
+    next(solver)
+    atoms = [('H', np.array([0.5, 0.0, 0.0]))]
+    lattice = np.array([[3.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 3.0]])
+    energy, gradients = solver.send((atoms, lattice))
+
+    assert energy == pytest.approx(0.25 + 27.0)
+    assert gradients.shape == (4, 3)
+    np.testing.assert_allclose(gradients[0], 2 * atoms[0][1] / angstrom, atol=1e-6)
+    np.testing.assert_allclose(gradients[1:], 2 * lattice / angstrom, atol=1e-6)
+
+
+def test_generic_solver_forwards_extra_args_and_kwargs():
+    def f(atoms, lattice, scale, *, offset):
+        coords = np.array([c for _, c in atoms])
+        return scale * float(np.sum((coords - offset) ** 2))
+
+    solver = GenericSolver(f, 3.0, offset=np.array([1.0, 0.0, 0.0]))
+    next(solver)
+    atoms = [('H', np.array([0.0, 0.0, 0.0]))]
+    energy, gradients = solver.send((atoms, None))
+
+    assert energy == pytest.approx(3.0)
+    np.testing.assert_allclose(
+        gradients[0],
+        3.0 * 2 * (atoms[0][1] - np.array([1.0, 0.0, 0.0])) / angstrom,
+        atol=1e-6,
+    )
+
+
+def test_generic_solver_accepts_custom_delta():
+    # Pop the `delta` kwarg out of kwargs so it's not forwarded to f.
+    captured = {}
+
+    def f(atoms, lattice):
+        captured['called'] = True
+        coords = np.array([c for _, c in atoms])
+        return float(np.sum(coords**2))
+
+    solver = GenericSolver(f, delta=1e-2)
+    next(solver)
+    atoms = [('H', np.array([0.3, 0.0, 0.0]))]
+    energy, gradients = solver.send((atoms, None))
+
+    assert captured['called']
+    assert energy == pytest.approx(0.09)
+    np.testing.assert_allclose(gradients[0], 2 * atoms[0][1] / angstrom, atol=1e-4)


### PR DESCRIPTION
## Summary

Adds unit tests for the previously thin areas of the test suite. Per-module coverage:

| File | Before | After |
|---|---|---|
| `geomlib.py` | 64% | 99% |
| `solvers.py` | 41% | 97% |
| `optimize.py` | 75% | 100% |
| `cli.py` | 24% | 75% |
| `species_data.py` | 85% | 100% |
| `coords.py` | 88% | 96% |
| `Math.py` | 89% | 91% |
| **Total** | **77%** | **95%** |

What was added:
- `geomlib` — XYZ/mopac dump, `write`/`readfile` dispatch and error paths, `super_circum`, `supercell`, `bondmatrix`, `masses`/`cms`/`inertia`, `dist_diff` with `other=`.
- `GenericSolver` — finite-difference gradient against the analytical one (molecule and crystal), `*args`/`**kwargs` forwarding, custom `delta`.
- `optimize` — the `trajectory=` branch (asserts the right number of XYZ frames).
- `cli` — `get_berny`, `init`, `berny_unpickled` round-trip, `driver` exit codes (0/1/10), `main` dispatch for `--init` and the default driver path.
- `species_data` — unknown-symbol / unknown-number `KeyError` paths.
- `coords` — `__repr__` with connectivity, near-π and near-0 dihedral gradients, near-π angle gradient, `dihedral=False`, crystal `_reduce`, `InternalCoords.__repr__`/`__str__`.
- `Math` — `pinv` warning band.

What's left uncovered (out of scope for this PR):
- `cli.server` socket loop and the `args.socket` `main` branch.
- A few `fit_cubic`/`fit_quartic` branches that take some algebra to construct.
- `MopacSolver` crystal-lattice branch (would need a crystal integration test).

## Test plan

- [x] `scripts/check.sh` passes locally (flake8, black, isort, pydocstyle, pytest)
- [x] `python -m coverage run -m pytest && coverage report` shows 95% total
- [x] CI matrix (3.9–3.13) green
- [x] Codecov shows the expected jump


---
_Generated by [Claude Code](https://claude.ai/code/session_01RAZ6yshYkyZXB3WHRpJK5U)_