### PR TITLE
Re-baseline mopac_pm7_steps against CI; loosen MOPAC assertion to ±3

### DIFF
--- a/tests/data/birkholz_schlegel/SOURCE.md
+++ b/tests/data/birkholz_schlegel/SOURCE.md
@@ -28,9 +28,13 @@ B3LYP/6-31G(d,p)). The ``pyberny_steps`` and ``mopac_pm7_steps`` fields are
 populated by running ``scripts/benchmark.py`` and committing the measured
 counts as a regression baseline.
 
-``mopac_pm7_steps`` is left ``null`` for ``bisphenol_a``, ``ochratoxin_a``
-and ``raffinose``: these did not converge with PM7 within pyberny's default
-100-step ceiling and so have no meaningful step count to record.
+``mopac_pm7_steps`` is left ``null`` for ``bisphenol_a``: this one does not
+converge with PM7 within pyberny's default 100-step ceiling and so has no
+meaningful step count to record. The reference values come from a run on
+GitHub Actions' ``ubuntu-latest`` (MOPAC 23.2.5, BLAS threads pinned to the
+runner's physical-core count); MOPAC PM7 is not bitwise-reproducible across
+hosts, so the ``-m benchmark`` test compares with a small ±3 step
+tolerance.
 
 Coordinate data is treated as factual and is redistributed under pyberny's
 MPL-2.0 license, with attribution to Birkholz & Schlegel via this file and

--- a/tests/data/birkholz_schlegel/reference.json
+++ b/tests/data/birkholz_schlegel/reference.json
@@ -13,7 +13,7 @@
   "avobenzone": {
     "atoms": 45,
     "charge": 0,
-    "mopac_pm7_steps": 90,
+    "mopac_pm7_steps": 94,
     "mult": 1,
     "name": "Avobenzone",
     "paper_steps": 43,
@@ -24,7 +24,7 @@
   "azadirachtin": {
     "atoms": 95,
     "charge": 0,
-    "mopac_pm7_steps": 61,
+    "mopac_pm7_steps": 60,
     "mult": 1,
     "name": "Azadirachtin",
     "paper_steps": 77,
@@ -46,7 +46,7 @@
   "cetirizine": {
     "atoms": 52,
     "charge": 0,
-    "mopac_pm7_steps": 57,
+    "mopac_pm7_steps": 58,
     "mult": 1,
     "name": "Cetirizine",
     "paper_steps": 35,
@@ -134,7 +134,7 @@
   "ochratoxin_a": {
     "atoms": 45,
     "charge": 0,
-    "mopac_pm7_steps": null,
+    "mopac_pm7_steps": 67,
     "mult": 1,
     "name": "Ochratoxin A",
     "paper_steps": 31,
@@ -156,7 +156,7 @@
   "raffinose": {
     "atoms": 66,
     "charge": 0,
-    "mopac_pm7_steps": null,
+    "mopac_pm7_steps": 99,
     "mult": 1,
     "name": "Raffinose",
     "paper_steps": 53,
@@ -167,7 +167,7 @@
   "sphingomyelin": {
     "atoms": 84,
     "charge": 0,
-    "mopac_pm7_steps": 87,
+    "mopac_pm7_steps": 95,
     "mult": 1,
     "name": "Sphingomyelin",
     "paper_steps": 56,
@@ -178,7 +178,7 @@
   "tamoxifen": {
     "atoms": 57,
     "charge": 0,
-    "mopac_pm7_steps": 72,
+    "mopac_pm7_steps": 70,
     "mult": 1,
     "name": "Tamoxifen",
     "paper_steps": 35,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -19,6 +19,7 @@ DATA = Path(__file__).parent / 'data' / 'birkholz_schlegel'
 REF = json.loads((DATA / 'reference.json').read_text())
 
 PYBERNY_STEP_MARGIN = 3
+MOPAC_STEP_MARGIN = 3
 
 
 @pytest.mark.benchmark
@@ -72,4 +73,10 @@ def test_mopac_pm7(name):
     berny = Berny(geom)
     optimize(berny, MopacSolver(charge=ref['charge'], mult=ref['mult']))
     assert berny.converged, f'{name}: did not converge'
-    assert berny._n == expected, f'{name}: {berny._n} steps vs reference {expected}'
+    # MOPAC PM7 is not bitwise-reproducible across hosts: BLAS/LAPACK
+    # summation order and threading produce small gradient differences
+    # that propagate over the optimizer's 30-100 iterations. The reference
+    # numbers come from ubuntu-latest CI; tolerate a small drift.
+    assert (
+        abs(berny._n - expected) <= MOPAC_STEP_MARGIN
+    ), f'{name}: {berny._n} steps vs reference {expected} (±{MOPAC_STEP_MARGIN})'


### PR DESCRIPTION
## Summary

Follow-up to #55. Running `scripts/benchmark.py --solver mopac` through the new `Benchmark` workflow ([run 25957080035](https://github.com/jhrmnn/pyberny/actions/runs/25957080035)) on `ubuntu-latest` revealed that **MOPAC PM7 is not bitwise-reproducible across hosts**: the original `mopac_pm7_steps` values, measured locally inside my Claude container, disagree with the CI run for 5 molecules (±1 to ±8 steps) and two more cases that hit pyberny's 100-step ceiling locally actually converge in CI.

| Molecule | Old (local) | New (CI) | Δ |
|---|---:|---:|---:|
| avobenzone | 90 | 94 | +4 |
| azadirachtin | 61 | 60 | −1 |
| cetirizine | 57 | 58 | +1 |
| ochratoxin_a | null (100, no) | 67 | newly converged |
| raffinose | null (100, no) | 99 | newly converged |
| sphingomyelin | 87 | 95 | +8 |
| tamoxifen | 72 | 70 | −2 |

The divergence concentrates in the larger / floppier molecules — expected signature of accumulated gradient noise from BLAS/LAPACK summation-order differences, not a bug.

bisphenol_a still hits the 100-step ceiling on both hosts and stays `null`.

## Changes

- **`tests/data/birkholz_schlegel/reference.json`** — replace 5 differing values with the CI numbers, fill in 67/99 for ochratoxin_a/raffinose; bisphenol_a stays `null`. 18/19 molecules now seeded.
- **`tests/test_benchmark.py`** — switch the MOPAC assertion from strict `berny._n == expected` to `abs(berny._n - expected) <= MOPAC_STEP_MARGIN` (=3, mirroring `PYBERNY_STEP_MARGIN`). Tight enough to catch a real regression, loose enough to absorb the observed cross-host drift. Comment explains why.
- **`tests/data/birkholz_schlegel/SOURCE.md`** — drop ochratoxin_a / raffinose from the null-entry note (only bisphenol_a remains), explain the CI-canonical baseline and ±3 tolerance.

## Test plan

- [x] `bash scripts/check.sh` — flake8 / black / isort / pydocstyle / pytest all pass.
- [x] `pytest --collect-only -q -m benchmark | grep -c test_mopac_pm7` → 19; bisphenol_a parametrization will `pytest.skip` (still `null`), the other 18 will run.
- [x] (Maintainer) Trigger the `Benchmark` workflow on this branch with `--solver mopac` to confirm the 18 non-null molecules pass the ±3 assertion in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R975zLdSyhmW4J1acKb31M)_