### PR TITLE
benchmark CI: regress step count with a 7% gate; raise maxsteps to 110

### DIFF
--- a/scripts/aggregate_benchmark.py
+++ b/scripts/aggregate_benchmark.py
@@ -7,12 +7,12 @@ solver via ``benchmark.format_table`` / ``format_errors``, appends the result
 to ``$GITHUB_STEP_SUMMARY`` (when set) and writes ``results/summary.md``.
 
 Exits 1 if any molecule with a non-``null`` reference entry for the active
-solver either failed to converge or deviates from the reference step count
-by more than 2 — same rule as ``benchmark.py``'s exit-code logic.
-``pyberny_steps`` is currently ``null`` for every entry, so pyscf is in
-baseline-establishment mode: no pyscf run can trip either half of this gate
-yet. Fill in ``pyberny_steps`` as pyscf results stabilize to enable the
-regression check.
+solver either failed to converge or drifts from its reference step count
+by more than 7% (with an absolute floor of 2 steps) — same rule as
+``benchmark.py``'s exit-code logic. ``pyberny_steps`` is currently
+``null`` for every entry, so pyscf is in baseline-establishment mode: no
+pyscf run can trip either half of this gate yet. Fill in ``pyberny_steps``
+as pyscf results stabilize to enable the regression check.
 """
 
 import argparse

--- a/scripts/aggregate_benchmark.py
+++ b/scripts/aggregate_benchmark.py
@@ -23,7 +23,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from benchmark import DATA, format_errors, format_table  # noqa: E402
+from benchmark import (  # noqa: E402
+    DATA,
+    format_errors,
+    format_table,
+    regression_reason,
+)
 
 REF_KEY = {'mopac': 'mopac_pm7_steps', 'pyscf': 'pyberny_steps'}
 
@@ -81,14 +86,9 @@ def violations(reference, solver, rows_by_name):
     key = REF_KEY[solver]
     out = []
     for n, r in rows_by_name.items():
-        ref = reference[n][key]
-        if ref is None:
-            continue
-        if not r['converged']:
-            out.append((n, 'did not converge'))
-        elif abs(r['steps'] - ref) > 2:
-            drift = r['steps'] - ref
-            out.append((n, f"{r['steps']} steps vs ref {ref} ({drift:+d})"))
+        reason = regression_reason(r, reference[n][key])
+        if reason:
+            out.append((n, reason))
     return out
 
 

--- a/scripts/aggregate_benchmark.py
+++ b/scripts/aggregate_benchmark.py
@@ -6,11 +6,13 @@ re-sorts rows to ``sorted(reference)`` order, renders one markdown table per
 solver via ``benchmark.format_table`` / ``format_errors``, appends the result
 to ``$GITHUB_STEP_SUMMARY`` (when set) and writes ``results/summary.md``.
 
-Exits 1 if any molecule failed to converge and its reference entry for that
-solver is not ``null`` — same rule as ``benchmark.py``'s exit-code logic.
+Exits 1 if any molecule with a non-``null`` reference entry for the active
+solver either failed to converge or deviates from the reference step count
+by more than 2 — same rule as ``benchmark.py``'s exit-code logic.
 ``pyberny_steps`` is currently ``null`` for every entry, so pyscf is in
-baseline-establishment mode: no pyscf run can trip this gate yet. Fill in
-``pyberny_steps`` as pyscf results stabilize to enable the regression check.
+baseline-establishment mode: no pyscf run can trip either half of this gate
+yet. Fill in ``pyberny_steps`` as pyscf results stabilize to enable the
+regression check.
 """
 
 import argparse
@@ -77,11 +79,17 @@ def render(reference, solver, rows_by_name):
 
 def violations(reference, solver, rows_by_name):
     key = REF_KEY[solver]
-    return [
-        n
-        for n, r in rows_by_name.items()
-        if not r['converged'] and reference[n][key] is not None
-    ]
+    out = []
+    for n, r in rows_by_name.items():
+        ref = reference[n][key]
+        if ref is None:
+            continue
+        if not r['converged']:
+            out.append((n, 'did not converge'))
+        elif abs(r['steps'] - ref) > 2:
+            drift = r['steps'] - ref
+            out.append((n, f"{r['steps']} steps vs ref {ref} ({drift:+d})"))
+    return out
 
 
 def main(argv=None):
@@ -101,7 +109,8 @@ def main(argv=None):
             continue
         parts.append(f'## {solver}\n\n' + render(reference, solver, rows_by_name))
         failed.extend(
-            f'{solver}/{n}' for n in violations(reference, solver, rows_by_name)
+            f'{solver}/{n}: {reason}'
+            for n, reason in violations(reference, solver, rows_by_name)
         )
 
     summary = '\n'.join(parts)
@@ -114,7 +123,9 @@ def main(argv=None):
     print(summary, end='')
 
     if failed:
-        print(f'\nUnexpected non-convergence: {failed}', file=sys.stderr)
+        print('\nBenchmark regressions:', file=sys.stderr)
+        for entry in failed:
+            print(f'  {entry}', file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -148,6 +148,24 @@ def format_errors(rows):
     return '\n'.join(lines) + '\n'
 
 
+def regression_reason(row, ref):
+    """Return ``None`` if the row passes the regression gate, else a reason.
+
+    ``ref`` is the reference step count for the row's solver (or ``None`` if
+    no baseline is recorded, in which case the gate is skipped). A row fails
+    if it didn't converge, or if its step count drifted from ``ref`` by more
+    than 2 (the same tolerance ``tests/test_optimize.py`` uses).
+    """
+    if ref is None:
+        return None
+    if not row['converged']:
+        return 'did not converge'
+    drift = row['steps'] - ref
+    if abs(drift) > 2:
+        return f"{row['steps']} steps vs ref {ref} ({drift:+d})"
+    return None
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument('--solver', choices=['pyscf', 'mopac'], required=True)
@@ -190,19 +208,20 @@ def main(argv=None):
     if errors:
         print(errors, end='')
 
-    # Treat documented-null reference entries (e.g. MOPAC's three
-    # known non-convergers) as expected rather than failing the run.
+    # Treat documented-null reference entries (e.g. MOPAC's one
+    # known non-converger) as expected rather than failing the run.
     ref_key = {'mopac': 'mopac_pm7_steps', 'pyscf': 'pyberny_steps'}[args.solver]
-
-    def passes(row):
-        ref = reference[row['name']][ref_key]
-        if ref is None:
-            return True
-        if not row['converged']:
-            return False
-        return abs(row['steps'] - ref) <= 2
-
-    return 0 if all(passes(row) for row in rows) else 1
+    regressions = [
+        (row['name'], regression_reason(row, reference[row['name']][ref_key]))
+        for row in rows
+    ]
+    regressions = [(n, r) for n, r in regressions if r]
+    if regressions:
+        print('\nBenchmark regressions:', file=sys.stderr)
+        for n, reason in regressions:
+            print(f'  {n}: {reason}', file=sys.stderr)
+        return 1
+    return 0
 
 
 if __name__ == '__main__':

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -10,9 +10,11 @@ PySCF mode drives the optimization through ``pyscf.geomopt.berny_solver``
 and requires ``pip install pyberny[benchmark]``; MOPAC mode uses
 :func:`berny.solvers.MopacSolver` (charge and multiplicity from
 ``reference.json``) and requires a ``mopac`` binary on ``$PATH``.
-Molecules whose ``<solver>_steps`` reference value is ``null`` in
-``reference.json`` are documented non-convergers / unmeasured and do not
-contribute to the script's exit code.
+A molecule fails the run when it either does not converge or its step
+count deviates from the reference by more than 2; molecules whose
+``<solver>_steps`` reference value is ``null`` in ``reference.json`` are
+documented non-convergers / unmeasured and do not contribute to the
+script's exit code.
 """
 
 # Pin numeric-library thread counts to physical cores before importing
@@ -191,13 +193,16 @@ def main(argv=None):
     # Treat documented-null reference entries (e.g. MOPAC's three
     # known non-convergers) as expected rather than failing the run.
     ref_key = {'mopac': 'mopac_pm7_steps', 'pyscf': 'pyberny_steps'}[args.solver]
-    return (
-        0
-        if all(
-            row['converged'] or reference[row['name']][ref_key] is None for row in rows
-        )
-        else 1
-    )
+
+    def passes(row):
+        ref = reference[row['name']][ref_key]
+        if ref is None:
+            return True
+        if not row['converged']:
+            return False
+        return abs(row['steps'] - ref) <= 2
+
+    return 0 if all(passes(row) for row in rows) else 1
 
 
 if __name__ == '__main__':

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -11,10 +11,11 @@ and requires ``pip install pyberny[benchmark]``; MOPAC mode uses
 :func:`berny.solvers.MopacSolver` (charge and multiplicity from
 ``reference.json``) and requires a ``mopac`` binary on ``$PATH``.
 A molecule fails the run when it either does not converge or its step
-count deviates from the reference by more than 2; molecules whose
-``<solver>_steps`` reference value is ``null`` in ``reference.json`` are
-documented non-convergers / unmeasured and do not contribute to the
-script's exit code.
+count drifts from the reference by more than 7% (with an absolute floor
+of 2 steps, so the gate stays meaningful for small references);
+molecules whose ``<solver>_steps`` reference value is ``null`` in
+``reference.json`` are documented non-convergers / unmeasured and do not
+contribute to the script's exit code.
 """
 
 # Pin numeric-library thread counts to physical cores before importing
@@ -93,7 +94,10 @@ def run_mopac(name, ref):
     from berny.solvers import MopacSolver
 
     geom = geomlib.readfile(str(DATA / f'{name}.xyz'))
-    berny = Berny(geom)
+    # raffinose converges in ~100 steps on CI MOPAC, right at pyberny's
+    # default 100-step ceiling; raise it so a +1 jitter doesn't flip the
+    # row from "converged in 99" to "did not converge".
+    berny = Berny(geom, maxsteps=110)
     optimize(berny, MopacSolver(charge=ref['charge'], mult=ref['mult']))
     return berny.converged, berny._n
 
@@ -154,15 +158,17 @@ def regression_reason(row, ref):
     ``ref`` is the reference step count for the row's solver (or ``None`` if
     no baseline is recorded, in which case the gate is skipped). A row fails
     if it didn't converge, or if its step count drifted from ``ref`` by more
-    than 2 (the same tolerance ``tests/test_optimize.py`` uses).
+    than ``max(2, round(0.07 * ref))`` steps — a 7% band, floored at 2 so
+    the gate stays meaningful for small references.
     """
     if ref is None:
         return None
     if not row['converged']:
         return 'did not converge'
     drift = row['steps'] - ref
-    if abs(drift) > 2:
-        return f"{row['steps']} steps vs ref {ref} ({drift:+d})"
+    tolerance = max(2, round(0.07 * ref))
+    if abs(drift) > tolerance:
+        return f"{row['steps']} steps vs ref {ref} ({drift:+d}, tol {tolerance})"
     return None
 
 

--- a/tests/data/birkholz_schlegel/SOURCE.md
+++ b/tests/data/birkholz_schlegel/SOURCE.md
@@ -29,13 +29,13 @@ populated by running ``scripts/benchmark.py`` and committing the measured
 counts as a regression baseline.
 
 ``mopac_pm7_steps`` is left ``null`` for ``bisphenol_a``: this one does not
-converge with PM7 within pyberny's default 100-step ceiling and so has no
+converge with PM7 within the benchmark's 110-step ceiling and so has no
 meaningful step count to record. The reference values come from a run on
 GitHub Actions' ``ubuntu-latest`` (MOPAC 23.2.5, BLAS threads pinned to the
 runner's physical-core count); MOPAC PM7 is not bitwise-reproducible across
 hosts, so ``scripts/benchmark.py`` and ``scripts/aggregate_benchmark.py``
-allow each row to drift by up to ±2 steps from its reference before failing
-the run.
+allow each row to drift from its reference by up to 7% (with an absolute
+floor of 2 steps) before failing the run.
 
 Coordinate data is treated as factual and is redistributed under pyberny's
 MPL-2.0 license, with attribution to Birkholz & Schlegel via this file and

--- a/tests/data/birkholz_schlegel/SOURCE.md
+++ b/tests/data/birkholz_schlegel/SOURCE.md
@@ -33,8 +33,9 @@ converge with PM7 within pyberny's default 100-step ceiling and so has no
 meaningful step count to record. The reference values come from a run on
 GitHub Actions' ``ubuntu-latest`` (MOPAC 23.2.5, BLAS threads pinned to the
 runner's physical-core count); MOPAC PM7 is not bitwise-reproducible across
-hosts, so the ``-m benchmark`` test compares with a small ±3 step
-tolerance.
+hosts, so ``scripts/benchmark.py`` and ``scripts/aggregate_benchmark.py``
+allow each row to drift by up to ±2 steps from its reference before failing
+the run.
 
 Coordinate data is treated as factual and is redistributed under pyberny's
 MPL-2.0 license, with attribution to Birkholz & Schlegel via this file and


### PR DESCRIPTION
## Summary

Add a regression gate on the optimization step count to the benchmark CI (`scripts/benchmark.py`, `scripts/aggregate_benchmark.py`) — previously the gate only failed on non-convergence, so a refactor that doubled the step count would have passed silently as long as the run still converged.

- Each row is compared against its `<solver>_steps` entry in `tests/data/birkholz_schlegel/reference.json`; the run fails when `|steps − reference| > max(2, round(0.07 · reference))`. The starting target was a fixed ±2, but the first CI run showed `avobenzone` legitimately drifting 5 steps on a 94-step optimization (≈5.3%) — within typical PM7 nondeterminism. A 7% relative band with an absolute floor of 2 steps accommodates that noise while still being meaningful for small references (e.g. `estradiol` at 11 keeps a ±2 band rather than the ~±1 a pure 7% rule would give).
- Raised the benchmark's MOPAC `maxsteps` from pyberny's default 100 to 110. `raffinose` (ref 99) and `zn_edta` (ref 99) sit right against the old ceiling; a +1 step jitter flipped `raffinose` from "converged in 99" to "did not converge in 100" on the same run, independent of any step-count tolerance.
- Null reference entries (currently `bisphenol_a` for MOPAC, and all 18 `pyberny_steps` for PySCF) still skip the check — PySCF stays in baseline-establishment mode until `pyberny_steps` is populated.
- The aggregator's stderr block now prints one regression per line with the kind (`did not converge` or `N steps vs ref M (+/-K, tol T)`), so CI output is diagnosable. `scripts/benchmark.py` emits the same per-row reasons before exiting nonzero, so single-shard local runs are equally informative.

## Test plan

- [x] `scripts/check.sh` (flake8, black, isort, pydocstyle, pytest — 102 passed)
- [x] Smoke test of `regression_reason()` and `aggregate_benchmark.violations()` against the four-case matrix (null ref / within tolerance / drift exceeds tolerance / non-converged)
- [x] Verified all 17 converged rows from the most recent CI run pass the new gate; remaining `raffinose` non-convergence is what the `maxsteps=110` bump addresses
- [x] CI `fast-mopac` matrix exercises both the loosened gate and the new ceiling against real MOPAC step counts on this PR

https://claude.ai/code/session_01S66BKXtW8pfhhJCjxaMyiM