### PR TITLE
doc: parse inline markup inside :sm: / :pb: callouts

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,6 +5,8 @@ from importlib.metadata import version as get_version
 
 import sphinxcontrib.katex as _katex
 import toml
+from docutils import nodes
+from docutils.parsers.rst import roles
 
 # Server-side KaTeX prerender so a math parse error fails the build.
 # sphinxcontrib-katex's throwOnError=False default is overridden so a
@@ -89,5 +91,23 @@ def skip_namedtuples(app, what, name, obj, skip, options):
         return True
 
 
+def _callout_role(css_class):
+    """Inline role that wraps content in <span class=css_class> while still
+    parsing inline markup (citations, refs, code spans, etc.) inside the
+    body. A bare `.. role:: foo` directive instead treats its content as
+    plain text, which silently breaks links like `[BirkholzTCA16]_`.
+    """
+
+    def role(name, rawtext, text, lineno, inliner, options=None, content=None):
+        opts = (options or {}).copy()
+        opts.setdefault('classes', []).append(css_class)
+        children, messages = inliner.parse(text, lineno, inliner, inliner.parent)
+        return [nodes.inline(rawtext, '', *children, **opts)], messages
+
+    return role
+
+
 def setup(app):
     app.connect('autodoc-skip-member', skip_namedtuples)
+    roles.register_local_role('sm', _callout_role('sm'))
+    roles.register_local_role('pb', _callout_role('pb'))

--- a/doc/standard_method.rst
+++ b/doc/standard_method.rst
@@ -1,9 +1,6 @@
 Standard method — full reference
 ================================
 
-.. role:: sm
-.. role:: pb
-
 This page documents the *standard method* (SM) for geometry optimization in
 sufficient detail to reimplement it from scratch. The SM was defined in the
 appendix of [BirkholzTCA16]_ as a reference algorithm against which various


### PR DESCRIPTION
## Summary

The `:sm:` / `:pb:` callouts in `doc/standard_method.rst` were declared via bare `.. role::` directives, which treat the role body as a single plain-text node. As a result, inline markup inside a callout — citation refs like `[BirkholzTCA16]_`, cross-refs, code spans — silently rendered as literal text instead of resolving.

This PR replaces the two RST `role` declarations with a small custom role registered in `doc/conf.py` that wraps the body in `<span class="sm">` (or `pb`) while still passing it through the docutils inliner, so all standard inline markup works inside a callout.

Verified: the previously broken `:sm:`Note (unspecified in [BirkholzTCA16]_):`` now renders with `[BirkholzTCA16]` as a working `<a class="reference internal" href="algorithm.html#birkholztca16">…</a>` link, and other callouts that contain only plain text are unaffected.

## Test plan

- [x] `scripts/check.sh` passes (flake8 / black / isort / pydocstyle / pytest / sphinx-build).
- [x] Inspected `_check/standard_method.html`: every `<span class="sm">` and `<span class="pb">` carries the expected class; the citation inside the first `sm` callout is a resolved link, not literal text.
- [ ] Visual review of rendered HTML on the deployed site.

https://claude.ai/code/session_01StQMvdNiLv7wDTvGQ6aZnw

---
_Generated by [Claude Code](https://claude.ai/code/session_01StQMvdNiLv7wDTvGQ6aZnw)_