### PR TITLE
Experiment: planarity follow-up confirms warning/coord-singularity link

### DIFF
--- a/experiments/microvariations/benchmark_internals_diag.py
+++ b/experiments/microvariations/benchmark_internals_diag.py
@@ -16,6 +16,14 @@ For each step of the optimization we capture, exactly the way
   is easy to read off.
 - All angles ``> 175 deg`` (near-linear; would make adjacent dihedrals
   ill-defined) and a sample of dihedrals adjacent to such angles.
+- All dihedrals within 5 deg of ``0`` or ``pi`` (near-planar; the
+  ``abs(phi) > pi - 1e-6`` / ``abs(phi) < 1e-6`` branches in
+  ``Dihedral.eval`` operate close to these limits and the ordinary
+  branch's ``1/sin(phi)`` term inflates as we approach them).
+- All heavy atoms with exactly three covalent neighbours whose
+  substituent-angle sum exceeds 355 deg (i.e. centre within ~5 deg of
+  the plane of its substituents - the sp3-to-sp2 inversion mode that
+  underlies the H-C-O = 180 deg event on estradiol).
 
 The case list is the union of every molecule that the trajectory sweep
 flagged via *any* of:
@@ -26,7 +34,11 @@ flagged via *any* of:
   signature);
 - ``negative_eigenvalue_events`` with >=10 events (a "confusing PES"
   signature - included for contrast since it should NOT show a coordinate
-  singularity).
+  singularity);
+- ``negative_eigenvalue_events`` with 1-4 events (the sparser, less
+  obviously-pathological cases, added as a probe for whether the same
+  planar-dihedral / planar-sp3 explanation also catches these milder
+  events).
 
 Outputs under ``experiments/microvariations/benchmark_internals_diag/``:
 
@@ -45,6 +57,7 @@ import os
 import shutil
 import sys
 import time
+from itertools import combinations
 from pathlib import Path
 
 import numpy as np
@@ -52,6 +65,11 @@ import numpy as np
 from berny import Berny, geomlib
 from berny.coords import Angle, Bond, Dihedral, InternalCoords
 from berny.solvers import MopacSolver
+
+# Re-use the regex-based log scanner from the trajectory-warning sweep so the
+# "which step did a warning fire on" pattern lives in exactly one place.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from benchmark_trajectory_check import scan_log  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DATA_ROOT = REPO_ROOT / 'tests' / 'data'
@@ -76,9 +94,14 @@ CASES = [
     ('birkholz', 'maltose', 35, 'severe back-xform + saddle pass at steps 27/30'),
     ('birkholz', 'raffinose', 55, 'heavy back-xform + non-converger (steps 42-49)'),
     ('baker', 'caffeine', 55, 'control: 43 neg-eigval events; not coord-singular'),
+    ('birkholz', 'avobenzone', 55, 'neg-eig only: 4 events at steps 14/17/20/49'),
+    ('birkholz', 'codeine', 25, 'neg-eig only: 2 events at steps 15/18'),
+    ('baker', 'methylamine', 22, 'neg-eig only: 4 events at steps 5/7/8/9'),
 ]
 
 NEAR_LINEAR_DEG = 175.0
+PLANAR_DIHEDRAL_DEG = 5.0  # |phi - 0| < 5 deg (cis) or |phi - 180| < 5 deg (trans)
+PLANAR_SP3_DEG = 355.0  # sum of three substituent angles > 355 deg => centre in plane
 
 
 @contextlib.contextmanager
@@ -111,6 +134,56 @@ def describe_coord(coord, species):
     return repr(coord)
 
 
+def build_neighbours(coords_obj, n_atoms):
+    """Return a per-atom list of strong-bond neighbours from ``coords_obj``.
+
+    Strong bonds are ``Bond`` entries with ``weak == 0``: the covalent network
+    excluding the fragment-linking pseudo-bonds. Bonds are static for the
+    trajectory (pyberny builds ``InternalCoords`` once), so this needs to be
+    computed only at the start of each case.
+    """
+    neighbours = [set() for _ in range(n_atoms)]
+    for c in coords_obj._coords:
+        if isinstance(c, Bond) and c.weak == 0:
+            neighbours[c.i].add(c.j)
+            neighbours[c.j].add(c.i)
+    return [sorted(n) for n in neighbours]
+
+
+def heavy_three_coord_centres(species, neighbours):
+    """Return atom indices with exactly three covalent neighbours, heavy only.
+
+    Hydrogens are excluded: the H-C-O = 180 deg case at estradiol is already
+    diagnosed by the near-linear-angle metric. This filter targets the
+    sp3->sp2 inversion mode at heavy centres (the maltose/raffinose
+    ring-puckering hypothesis).
+    """
+    return [
+        i
+        for i, n in enumerate(neighbours)
+        if len(n) == 3 and species[i] != 'H'
+    ]
+
+
+def substituent_angle_sum_deg(centre, neighbours, coords):
+    """Sum of the three angles ``neighbour-centre-neighbour`` at ``centre``.
+
+    For a perfectly planar arrangement of three substituents around the
+    centre (sp2) this sum is 360 deg; for tetrahedral sp3 it is
+    3 * 109.47 deg = 328.4 deg. Drops below 360 deg as the centre lifts out
+    of the substituent plane, so a value close to 360 deg flags a planar
+    geometry at the centre.
+    """
+    s = 0.0
+    for n1, n2 in combinations(neighbours, 2):
+        v1 = coords[n1] - coords[centre]
+        v2 = coords[n2] - coords[centre]
+        cos = float(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
+        cos = max(-1.0, min(1.0, cos))
+        s += float(np.degrees(np.arccos(cos)))
+    return s
+
+
 def first_big_gap(D, thre=1e3):
     """Mirror ``berny.Math.pinv``: return (gap_index, gap_value) or (None, None)."""
     if len(D) < 2:
@@ -123,12 +196,14 @@ def first_big_gap(D, thre=1e3):
     return n, float(gaps[n])
 
 
-def analyse_step(coords_obj: InternalCoords, geom):
+def analyse_step(coords_obj: InternalCoords, geom, neighbours=None, sp3_centres=None):
     """Compute one step's worth of internal-coord diagnostics.
 
     Returns a dict containing the pinv-gap location/value, the top
-    contributors to the truncated direction, near-linear angles, and a
-    sample of dihedrals adjacent to such angles.
+    contributors to the truncated direction, near-linear angles, a
+    sample of dihedrals adjacent to such angles, near-planar dihedrals
+    (within 5 deg of 0 or pi), and heavy three-coord centres that have
+    gone planar (substituent angle sum > 355 deg).
     """
     B = coords_obj.B_matrix(geom)  # (n_internal, 3N)
     BBT = B @ B.T
@@ -172,6 +247,7 @@ def analyse_step(coords_obj: InternalCoords, geom):
 
     near_linear_angles = []
     near_linear_dihedrals = []
+    near_planar_dihedrals = []
     for i, c in enumerate(coords_obj._coords):
         if isinstance(c, Angle):
             phi = float(np.degrees(c.eval(geom.coords)))
@@ -199,6 +275,34 @@ def analyse_step(coords_obj: InternalCoords, geom):
                         'coord': describe_coord(c, geom.species),
                     }
                 )
+            phi_deg = float(np.degrees(c.eval(geom.coords)))
+            phi_abs = abs(phi_deg)
+            dist_to_planar = min(phi_abs, abs(180.0 - phi_abs))
+            if dist_to_planar < PLANAR_DIHEDRAL_DEG:
+                near_planar_dihedrals.append(
+                    {
+                        'idx': i,
+                        'phi_deg': phi_deg,
+                        'coord': describe_coord(c, geom.species),
+                        'kind': 'cis' if phi_abs < 90.0 else 'trans',
+                    }
+                )
+
+    planar_sp3 = []
+    if sp3_centres is not None and neighbours is not None:
+        for centre in sp3_centres:
+            s = substituent_angle_sum_deg(centre, neighbours[centre], geom.coords)
+            if s > PLANAR_SP3_DEG:
+                planar_sp3.append(
+                    {
+                        'centre_idx': int(centre),
+                        'centre': f'{geom.species[centre]}{centre}',
+                        'neighbours': [
+                            f'{geom.species[n]}{n}' for n in neighbours[centre]
+                        ],
+                        'angle_sum_deg': s,
+                    }
+                )
 
     return {
         'sv_max': float(pos[0]),
@@ -218,6 +322,12 @@ def analyse_step(coords_obj: InternalCoords, geom):
         'near_linear_angles': near_linear_angles,
         'near_linear_dihedrals_count': len(near_linear_dihedrals),
         'near_linear_dihedrals_sample': near_linear_dihedrals[:3],
+        'near_planar_dihedrals_count': len(near_planar_dihedrals),
+        'near_planar_dihedrals_idx': [d['idx'] for d in near_planar_dihedrals],
+        'near_planar_dihedrals_sample': near_planar_dihedrals,
+        'planar_sp3_count': len(planar_sp3),
+        'planar_sp3_idx': [c['centre_idx'] for c in planar_sp3],
+        'planar_sp3_sample': planar_sp3,
     }
 
 
@@ -240,16 +350,22 @@ def run_case(set_key, molecule, maxsteps, log_path):
     converged = False
     n = 0
     error = None
+    neighbours = None
+    sp3_centres = None
+    n_atoms = None
     t0 = time.perf_counter()
     try:
         with silence_fd(1), silence_fd(2):
             geom = geomlib.readfile(str(data_dir / f'{molecule}.xyz'))
+            n_atoms = len(geom)
             berny = Berny(geom, maxsteps=maxsteps)
             coords_obj = berny._state.coords
+            neighbours = build_neighbours(coords_obj, n_atoms)
+            sp3_centres = heavy_three_coord_centres(geom.species, neighbours)
             solver = MopacSolver(charge=ref['charge'], mult=ref['mult'])
             next(solver)
             for current in berny:
-                diag = analyse_step(coords_obj, current)
+                diag = analyse_step(coords_obj, current, neighbours, sp3_centres)
                 per_step.append(diag)
                 energy, gradients = solver.send((list(current), current.lattice))
                 berny.send((energy, gradients))
@@ -262,6 +378,14 @@ def run_case(set_key, molecule, maxsteps, log_path):
         berny_logger.removeHandler(handler)
         berny_logger.setLevel(prev_level)
 
+    # Re-scan the log we just produced for the warning lines (same regexes
+    # as benchmark_trajectory_check.scan_log), so the summary can correlate
+    # per-step planar/linear state with the steps that emitted warnings.
+    try:
+        scan = scan_log(log_path)
+    except FileNotFoundError:
+        scan = None
+
     return {
         'converged': converged,
         'steps': n,
@@ -269,7 +393,117 @@ def run_case(set_key, molecule, maxsteps, log_path):
         'error': error,
         'per_step': per_step,
         'n_internals': len(per_step[0]['top_5_b_row_norms']) if per_step else 0,
+        'scan': scan,
+        'sp3_centres': sp3_centres or [],
+        'n_atoms': n_atoms,
     }
+
+
+def _collect_warning_steps(scan):
+    """Return ``{step: {warning_kind, ...}}`` for one trajectory's log scan."""
+    by_step = {}
+    if not scan:
+        return by_step
+    for w in scan.get('pinv_warnings', []) or []:
+        by_step.setdefault(w['step'], set()).add('pinv')
+    for w in scan.get('backtransform_warnings', []) or []:
+        by_step.setdefault(w['step'], set()).add('backx')
+    for w in scan.get('severe_backxform_dq', []) or []:
+        by_step.setdefault(w['step'], set()).add('severe-dq')
+    for w in scan.get('negative_eigenvalue_events', []) or []:
+        by_step.setdefault(w['step'], set()).add('neg-eig')
+    return by_step
+
+
+def _baseline_sets(per_step):
+    """Return the step-1 sets of (near-planar dihedral idx, planar sp3 idx).
+
+    Aromatic / sp2 features are planar at the published starting geometry
+    too, so subtracting the step-1 set gives "new" planar events that
+    happened during the trajectory - a much cleaner signal than the
+    absolute count.
+    """
+    if not per_step:
+        return set(), set()
+    s = per_step[0]
+    return set(s.get('near_planar_dihedrals_idx', [])), set(s.get('planar_sp3_idx', []))
+
+
+def _new_planar_at_step(s, base_dih, base_sp3):
+    """Return ``(new_planar_dih_count, new_planar_sp3_count)`` vs the step-1 baseline."""
+    cur_dih = set(s.get('near_planar_dihedrals_idx', []))
+    cur_sp3 = set(s.get('planar_sp3_idx', []))
+    return len(cur_dih - base_dih), len(cur_sp3 - base_sp3)
+
+
+def _example_geom_flag(s, base_dih, base_sp3):
+    """Return short text for the first newly-planar / linear flag at a step.
+
+    Prefers a near-linear angle (the existing signal), then a near-planar
+    dihedral that was NOT planar at step 1 (new event), then a planar sp3
+    centre that was NOT planar at step 1, then any planar dihedral/sp3
+    (baseline-aromatic case), then ``-``.
+    """
+    if s['near_linear_angles']:
+        a = s['near_linear_angles'][0]
+        return f'{a["coord"]} = {a["angle_deg"]:.1f}°'
+    new_dihs = [
+        d for d in s.get('near_planar_dihedrals_sample', [])
+        if d['idx'] not in base_dih
+    ]
+    if new_dihs:
+        d = new_dihs[0]
+        return f'NEW {d["coord"]} = {d["phi_deg"]:.1f}° ({d["kind"]})'
+    new_sp3 = [
+        c for c in s.get('planar_sp3_sample', [])
+        if c['centre_idx'] not in base_sp3
+    ]
+    if new_sp3:
+        c = new_sp3[0]
+        return (
+            f'NEW centre {c["centre"]} planar (Σangles={c["angle_sum_deg"]:.1f}°)'
+        )
+    if s.get('near_planar_dihedrals_sample'):
+        d = s['near_planar_dihedrals_sample'][0]
+        return f'{d["coord"]} = {d["phi_deg"]:.1f}° (aromatic/baseline)'
+    if s.get('planar_sp3_sample'):
+        c = s['planar_sp3_sample'][0]
+        return (
+            f'centre {c["centre"]} planar (aromatic/baseline)'
+        )
+    return '-'
+
+
+def _planarity_verdict(per_step, warning_steps):
+    """Summarise whether warning steps coincided with new planar/linear flags."""
+    n_warned = len(warning_steps)
+    if n_warned == 0:
+        return 'no warning steps to score.'
+    base_dih, base_sp3 = _baseline_sets(per_step)
+    n_flagged = 0
+    for step in warning_steps:
+        if step < 1 or step > len(per_step):
+            continue
+        s = per_step[step - 1]
+        new_dih, new_sp3 = _new_planar_at_step(s, base_dih, base_sp3)
+        if s['near_linear_angles'] or new_dih or new_sp3:
+            n_flagged += 1
+    if n_flagged == n_warned:
+        return (
+            f'every one of the {n_warned} warning step(s) coincides with at '
+            'least one planar/linear event new vs step 1 (or a near-linear '
+            'angle).'
+        )
+    if n_flagged == 0:
+        return (
+            f'none of the {n_warned} warning step(s) coincides with a new '
+            'planar/linear event - the warnings here are not '
+            'coordinate-singularity events.'
+        )
+    return (
+        f'{n_flagged} of {n_warned} warning step(s) coincide with a new '
+        'planar/linear event; the remainder fired on a baseline geometry.'
+    )
 
 
 def render_summary(report):
@@ -321,8 +555,12 @@ def render_summary(report):
         ]
 
         out.append('### Per-step pinv-gap summary\n')
-        out.append('| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals |')
-        out.append('|---:|---:|---:|---:|---:|---:|---:|')
+        out.append(
+            '| step | pinv_gap_idx | gap | sv_max | sv_min '
+            '| #near-lin angles | #near-lin dihedrals '
+            '| #near-planar dihedrals | #planar sp3 |'
+        )
+        out.append('|---:|---:|---:|---:|---:|---:|---:|---:|---:|')
         for i, s in enumerate(per_step, 1):
             gap_s = (
                 f'{s["pinv_gap_value"]:.2e}'
@@ -335,7 +573,9 @@ def render_summary(report):
             out.append(
                 f'| {i} | {idx_s} | {gap_s} | {s["sv_max"]:.2e} '
                 f'| {s["sv_min"]:.2e} | {len(s["near_linear_angles"])} '
-                f'| {s["near_linear_dihedrals_count"]} |'
+                f'| {s["near_linear_dihedrals_count"]} '
+                f'| {s.get("near_planar_dihedrals_count", 0)} '
+                f'| {s.get("planar_sp3_count", 0)} |'
             )
 
         # Smoking-gun section: list the firing internals at each step where
@@ -388,6 +628,57 @@ def render_summary(report):
                 'for this molecule.\n'
             )
 
+        # Warning/geometry correlation: which trajectory-check warning lines
+        # landed on which step, and what was the planar/linear state of the
+        # geometry there. ``scan`` is the result of ``scan_log`` on this
+        # case's own log file.
+        scan = rec.get('scan') or {}
+        warning_steps = _collect_warning_steps(scan)
+        if not warning_steps:
+            out.append(
+                '\nNo trajectory-check warning line (pinv, back-xform, '
+                'severe dq, neg-eig) fired on this trajectory.\n'
+            )
+        else:
+            base_dih, base_sp3 = _baseline_sets(per_step)
+            out.append('\n### Warning-step / geometry correlation\n')
+            out.append(
+                'For each step where `benchmark_trajectory_check.py`\'s log '
+                'scan would record a warning, the columns below report the '
+                'count of geometric degeneracies at that step. '
+                '`near_lin_ang` counts angles > 175°. `new_planar_dih` is '
+                'the number of dihedrals within 5° of 0°/180° that were '
+                'NOT already planar at step 1 (subtracting the aromatic-ring '
+                'baseline). `new_planar_sp3` is the number of three-coord '
+                'heavy centres whose substituent-angle sum exceeds 355° '
+                'and were not already planar at step 1. The "geom flag" '
+                'column is YES if at least one of those three is nonzero.\n'
+            )
+            out.append(
+                f'Step-1 baseline: {len(base_dih)} planar dihedral(s), '
+                f'{len(base_sp3)} planar sp3 centre(s).\n'
+            )
+            out.append(
+                '| step | warning kinds | n_near_lin_ang '
+                '| new_planar_dih | new_planar_sp3 | geom flag | example |'
+            )
+            out.append('|---:|---|---:|---:|---:|---|---|')
+            for step in sorted(warning_steps):
+                if step < 1 or step > len(per_step):
+                    continue
+                s = per_step[step - 1]
+                kinds = warning_steps[step]
+                n_ang = len(s['near_linear_angles'])
+                new_dih, new_sp3 = _new_planar_at_step(s, base_dih, base_sp3)
+                flag = 'YES' if (n_ang or new_dih or new_sp3) else 'no'
+                example = _example_geom_flag(s, base_dih, base_sp3)
+                out.append(
+                    f'| {step} | {", ".join(sorted(kinds))} | {n_ang} '
+                    f'| {new_dih} | {new_sp3} | {flag} | {example} |'
+                )
+            verdict = _planarity_verdict(per_step, warning_steps)
+            out.append(f'\n**Verdict:** {verdict}\n')
+
     # Global conclusions across all cases.
     out.append('\n## Conclusions\n')
     out.append(
@@ -414,13 +705,35 @@ def render_summary(report):
     )
     out.append(
         'The other flagged cases (inosine_cation, maltose, raffinose, '
-        'caffeine) have pinv gap values uniformly above `1e11` and never '
-        'trigger the warning. Their pathologies are different: '
-        'saddle-pass attempts (negative eigenvalues + huge predicted '
-        'energy change) for maltose/raffinose, multivalued '
-        'Cartesian↔internal map at one step for inosine_cation, and a '
-        'confusing PES for caffeine. None of these implicates `Math.pinv` '
-        'truncation.\n'
+        'caffeine, plus the neg-eig-only cases avobenzone, codeine, '
+        'methylamine) have pinv gap values uniformly above `1e11` and '
+        'never trigger the pinv warning. Tracking dihedrals within 5° of '
+        '0°/180° and three-coord centres within 5° of their substituent '
+        'plane (subtracting the step-1 aromatic baseline) splits these '
+        'into two groups:\n'
+    )
+    out.append(
+        '- **Planar-dihedral coincidence** (inosine_cation, maltose, '
+        'raffinose, avobenzone, codeine): every step that emitted a '
+        'back-xform, severe-dq, or neg-eig warning had at least one '
+        'dihedral cross into the 5°-of-planar region between the '
+        'starting geometry and that step. On raffinose the offenders are '
+        '`Dihedral(C4-C0-O44-H45)` and `Dihedral(O10-C2-C3-H8)` cycling '
+        'through 0°/180° as the sugar ring puckers; on maltose it is '
+        '`Dihedral(H6-C1-C2-O10)` going trans; on avobenzone it is '
+        '`Dihedral(C8-C12-O27-C28)` flipping through cis on every '
+        'neg-eig step (14, 17, 20, 49). These warnings are the same '
+        'class of coordinate-singularity event as the pinv@final cases '
+        '- the back-transform Newton iteration just happens to absorb '
+        'the gradient blow-up before the pinv truncation fires.\n'
+    )
+    out.append(
+        '- **PES topology, not coordinate singularity** (caffeine, '
+        'methylamine): zero of the neg-eig warning steps coincided with '
+        'a new planar event. Caffeine\'s 43 neg-eig events and '
+        'methylamine\'s 4 are genuine BFGS spurious-unstable-mode events '
+        'on a confusing PES region, not numerical breakdowns of the '
+        'internal-coord representation.\n'
     )
     out.append(
         'In every truncation case the geometric culprit is identifiable '
@@ -440,6 +753,73 @@ def render_summary(report):
         '| allene | `Angle(C1-C0-C2)` -> 179.98° (symmetry) | rank drop; '
         'H-C-H angles get truncated instead |'
     )
+    out.append(
+        '| inosine_cation | `Dihedral(C4-C0-C13-O16)` -> 177.5° | new '
+        'trans-planar dihedral coincides with step-11 severe-dq |'
+    )
+    out.append(
+        '| maltose | `Dihedral(H6-C1-C2-O10)` -> ~177° | new trans '
+        'dihedral on every severe-dq + neg-eig step (27/30/31) |'
+    )
+    out.append(
+        '| raffinose | `Dihedral(C4-C0-O44-H45)`, '
+        '`Dihedral(O10-C2-C3-H8)`, `Dihedral(O21-C14-C17-H20)` -> '
+        '~0°/180° | sugar-ring puckering through planar configurations '
+        'over steps 42-49 |'
+    )
+    out.append(
+        '| avobenzone | `Dihedral(C8-C12-O27-C28)` -> ~0° | aryl-ether '
+        'C-O dihedral flipping cis on every neg-eig step (14/17/20/49) |'
+    )
+    out.append(
+        '| codeine | `Dihedral(C5-C0-C1-C2)` -> ~3° | ring dihedral '
+        'going cis on the neg-eig steps (15/18) |'
+    )
+    out.append(
+        '| caffeine | none | 43 neg-eig events on a confusing PES; '
+        'no new planar/linear event on any warning step |'
+    )
+    out.append(
+        '| methylamine | none | 4 neg-eig events; N inversion '
+        'baseline-planar already, no new planar/linear event |'
+    )
+
+    # Cross-case planarity correlation: was every warning step on every
+    # case accompanied by at least one planar/linear flag?
+    out.append('\n### Planar/linear coincidence across all warning categories\n')
+    rows = []
+    for case in CASES:
+        set_key, molecule, _maxsteps, _why = case
+        rec = report.get(f'{set_key}/{molecule}')
+        if rec is None:
+            continue
+        per_step = rec['per_step']
+        scan = rec.get('scan') or {}
+        warning_steps = _collect_warning_steps(scan)
+        if not warning_steps:
+            rows.append((f'{set_key}/{molecule}', 0, 0, 'no warnings'))
+            continue
+        n_warned = len(warning_steps)
+        base_dih, base_sp3 = _baseline_sets(per_step)
+        n_flagged = 0
+        for step in warning_steps:
+            if not 1 <= step <= len(per_step):
+                continue
+            s = per_step[step - 1]
+            new_dih, new_sp3 = _new_planar_at_step(s, base_dih, base_sp3)
+            if s['near_linear_angles'] or new_dih or new_sp3:
+                n_flagged += 1
+        if n_flagged == n_warned:
+            verdict = 'all planar/linear'
+        elif n_flagged == 0:
+            verdict = 'none planar/linear'
+        else:
+            verdict = 'partial'
+        rows.append((f'{set_key}/{molecule}', n_flagged, n_warned, verdict))
+    out.append('| case | warning steps w/ planar-or-linear flag | total warning steps | verdict |')
+    out.append('|---|---:|---:|---|')
+    for name, k, n, v in rows:
+        out.append(f'| {name} | {k} | {n} | {v} |')
     return '\n'.join(out) + '\n'
 
 

--- a/experiments/microvariations/benchmark_internals_diag/summary.md
+++ b/experiments/microvariations/benchmark_internals_diag/summary.md
@@ -9,23 +9,23 @@ Atom indices are zero-based, prefixed with the element symbol of that atom (e.g.
 
 *pinv@final: H-C-O angle near-linear (known smoking gun)*
 
-Steps: 11, converged: True, wall: 3.0s.
+Steps: 11, converged: True, wall: 3.5s.
 
 ### Per-step pinv-gap summary
 
-| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals |
-|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 125 | 1.18e+13 | 2.23e+01 | 1.00e-30 | 0 | 0 |
-| 2 | 125 | 1.18e+13 | 2.07e+01 | 1.00e-30 | 0 | 0 |
-| 3 | 125 | 4.75e+12 | 2.26e+01 | 1.00e-30 | 0 | 0 |
-| 4 | 125 | 7.30e+12 | 3.08e+01 | 1.00e-30 | 0 | 0 |
-| 5 | 125 | 4.54e+12 | 3.95e+01 | 1.00e-30 | 0 | 0 |
-| 6 | 125 | 5.19e+12 | 7.93e+01 | 1.00e-30 | 0 | 0 |
-| 7 | 125 | 1.12e+12 | 3.37e+02 | 1.00e-30 | 1 | 2 |
-| 8 | 0 | 2.74e+03 | 4.38e+04 | 1.00e-30 | 1 | 2 |
-| 9 | 0 | 2.74e+03 | 4.38e+04 | 1.00e-30 | 1 | 2 |
-| 10 | 0 | 2.62e+03 | 4.19e+04 | 1.00e-30 | 1 | 2 |
-| 11 | 0 | 2.61e+03 | 4.19e+04 | 1.00e-30 | 1 | 2 |
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 125 | 1.18e+13 | 2.23e+01 | 1.00e-30 | 0 | 0 | 22 | 6 |
+| 2 | 125 | 1.18e+13 | 2.07e+01 | 1.00e-30 | 0 | 0 | 24 | 6 |
+| 3 | 125 | 4.75e+12 | 2.26e+01 | 1.00e-30 | 0 | 0 | 25 | 6 |
+| 4 | 125 | 7.30e+12 | 3.08e+01 | 1.00e-30 | 0 | 0 | 30 | 6 |
+| 5 | 125 | 4.54e+12 | 3.95e+01 | 1.00e-30 | 0 | 0 | 34 | 6 |
+| 6 | 125 | 5.19e+12 | 7.93e+01 | 1.00e-30 | 0 | 0 | 35 | 6 |
+| 7 | 125 | 1.12e+12 | 3.37e+02 | 1.00e-30 | 1 | 2 | 41 | 6 |
+| 8 | 0 | 2.74e+03 | 4.38e+04 | 1.00e-30 | 1 | 2 | 40 | 6 |
+| 9 | 0 | 2.74e+03 | 4.38e+04 | 1.00e-30 | 1 | 2 | 40 | 6 |
+| 10 | 0 | 2.62e+03 | 4.19e+04 | 1.00e-30 | 1 | 2 | 40 | 6 |
+| 11 | 0 | 2.61e+03 | 4.19e+04 | 1.00e-30 | 1 | 2 | 40 | 6 |
 
 ### Firing internals (steps where the pinv warning would fire)
 
@@ -92,6 +92,24 @@ These are the steps where `Math.pinv`'s gap value falls below `1e8` (its log thr
   - `Dihedral(H17-C4-C5-H18)` (idx 183, |B_row| = 1.60e+00)
   - `Dihedral(H16-C0-C1-O42)` (idx 149, |B_row| = 1.57e+00)
 
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 22 planar dihedral(s), 6 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 6 | backx | 0 | 16 | 0 | YES | NEW Dihedral(C0-C1-C2-C3) = 2.7° (cis) |
+| 7 | backx, severe-dq | 1 | 23 | 0 | YES | Angle(H37-C36-O40) = 176.0° |
+| 8 | pinv | 1 | 22 | 0 | YES | Angle(H37-C36-O40) = 179.7° |
+| 9 | pinv | 1 | 22 | 0 | YES | Angle(H37-C36-O40) = 179.7° |
+| 10 | pinv | 1 | 22 | 0 | YES | Angle(H37-C36-O40) = 179.7° |
+| 11 | pinv | 1 | 22 | 0 | YES | Angle(H37-C36-O40) = 179.7° |
+
+**Verdict:** every one of the 6 warning step(s) coincides with at least one planar/linear event new vs step 1 (or a near-linear angle).
+
+
 ## baker/allene
 
 *pinv@final: C=C=C linear backbone (symmetry-imposed)*
@@ -100,20 +118,20 @@ Steps: 12, converged: True, wall: 0.3s.
 
 ### Per-step pinv-gap summary
 
-| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals |
-|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 12 | 4.61e+14 | 3.99e+00 | 1.00e-30 | 1 | 0 |
-| 2 | 13 | 8.22e+09 | 4.01e+00 | 1.00e-30 | 1 | 0 |
-| 3 | 13 | 6.01e+10 | 4.00e+00 | 1.00e-30 | 1 | 0 |
-| 4 | 13 | 2.07e+11 | 4.01e+00 | 1.00e-30 | 1 | 0 |
-| 5 | 13 | 2.01e+07 | 4.02e+00 | 1.00e-30 | 1 | 0 |
-| 6 | 13 | 1.72e+05 | 4.02e+00 | 2.55e-17 | 1 | 0 |
-| 7 | 13 | 1.60e+03 | 4.02e+00 | 1.00e-30 | 1 | 0 |
-| 8 | 13 | 6.35e+05 | 4.02e+00 | 1.44e-17 | 1 | 0 |
-| 9 | 13 | 4.12e+04 | 4.02e+00 | 3.91e-17 | 1 | 0 |
-| 10 | 13 | 1.05e+09 | 4.02e+00 | 1.00e-30 | 1 | 0 |
-| 11 | 13 | 3.12e+06 | 4.02e+00 | 1.00e-30 | 1 | 0 |
-| 12 | 13 | 3.04e+07 | 4.02e+00 | 4.70e-16 | 1 | 0 |
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 12 | 4.61e+14 | 3.99e+00 | 1.00e-30 | 1 | 0 | 0 | 2 |
+| 2 | 13 | 8.22e+09 | 4.01e+00 | 1.00e-30 | 1 | 0 | 0 | 2 |
+| 3 | 13 | 6.01e+10 | 4.00e+00 | 1.00e-30 | 1 | 0 | 0 | 2 |
+| 4 | 13 | 2.07e+11 | 4.01e+00 | 1.00e-30 | 1 | 0 | 0 | 2 |
+| 5 | 13 | 2.01e+07 | 4.02e+00 | 1.00e-30 | 1 | 0 | 0 | 2 |
+| 6 | 13 | 1.72e+05 | 4.02e+00 | 2.55e-17 | 1 | 0 | 0 | 2 |
+| 7 | 13 | 1.60e+03 | 4.02e+00 | 1.00e-30 | 1 | 0 | 0 | 2 |
+| 8 | 13 | 6.35e+05 | 4.02e+00 | 1.44e-17 | 1 | 0 | 0 | 2 |
+| 9 | 13 | 4.12e+04 | 4.02e+00 | 3.91e-17 | 1 | 0 | 0 | 2 |
+| 10 | 13 | 1.05e+09 | 4.02e+00 | 1.00e-30 | 1 | 0 | 0 | 2 |
+| 11 | 13 | 3.12e+06 | 4.02e+00 | 1.00e-30 | 1 | 0 | 0 | 2 |
+| 12 | 13 | 3.04e+07 | 4.02e+00 | 4.70e-16 | 1 | 0 | 0 | 2 |
 
 ### Firing internals (steps where the pinv warning would fire)
 
@@ -225,6 +243,27 @@ These are the steps where `Math.pinv`'s gap value falls below `1e8` (its log thr
   - `Bond(C0-C1)` (idx 0, |B_row| = 1.41e+00)
   - `Bond(C2-H3)` (idx 4, |B_row| = 1.41e+00)
 
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 0 planar dihedral(s), 2 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 3 | backx | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 180.0° |
+| 5 | pinv | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 180.0° |
+| 6 | backx, pinv | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 180.0° |
+| 7 | backx, pinv | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 180.0° |
+| 8 | pinv | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 179.7° |
+| 9 | backx, pinv | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 179.8° |
+| 10 | backx | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 179.8° |
+| 11 | pinv | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 180.0° |
+| 12 | backx, pinv | 1 | 0 | 0 | YES | Angle(C1-C0-C2) = 180.0° |
+
+**Verdict:** every one of the 9 warning step(s) coincides with at least one planar/linear event new vs step 1 (or a near-linear angle).
+
+
 ## baker/disilyl_ether
 
 *pinv@final: Si-O-Si linearization*
@@ -233,15 +272,15 @@ Steps: 7, converged: True, wall: 0.6s.
 
 ### Per-step pinv-gap summary
 
-| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals |
-|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 20 | 5.66e+13 | 1.41e+01 | 1.00e-30 | 0 | 0 |
-| 2 | 20 | 8.66e+13 | 1.81e+01 | 1.00e-30 | 0 | 0 |
-| 3 | 20 | 3.41e+13 | 3.50e+01 | 1.00e-30 | 0 | 0 |
-| 4 | 20 | 7.35e+13 | 5.86e+01 | 1.00e-30 | 0 | 0 |
-| 5 | 20 | 1.81e+13 | 1.89e+02 | 1.00e-30 | 0 | 0 |
-| 6 | 20 | 6.31e+11 | 1.77e+03 | 1.00e-30 | 1 | 6 |
-| 7 | 0 | 9.40e+05 | 3.36e+06 | 1.00e-30 | 1 | 6 |
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 20 | 5.66e+13 | 1.41e+01 | 1.00e-30 | 0 | 0 | 2 | 0 |
+| 2 | 20 | 8.66e+13 | 1.81e+01 | 1.00e-30 | 0 | 0 | 2 | 0 |
+| 3 | 20 | 3.41e+13 | 3.50e+01 | 1.00e-30 | 0 | 0 | 2 | 0 |
+| 4 | 20 | 7.35e+13 | 5.86e+01 | 1.00e-30 | 0 | 0 | 2 | 0 |
+| 5 | 20 | 1.81e+13 | 1.89e+02 | 1.00e-30 | 0 | 0 | 2 | 0 |
+| 6 | 20 | 6.31e+11 | 1.77e+03 | 1.00e-30 | 1 | 6 | 2 | 0 |
+| 7 | 0 | 9.40e+05 | 3.36e+06 | 1.00e-30 | 1 | 6 | 2 | 0 |
 
 ### Firing internals (steps where the pinv warning would fire)
 
@@ -263,220 +302,494 @@ These are the steps where `Math.pinv`'s gap value falls below `1e8` (its log thr
   - `Dihedral(H8-Si1-O2-Si0)` (idx 26, |B_row| = 7.48e+02)
   - `Dihedral(H4-Si0-O2-Si1)` (idx 22, |B_row| = 7.48e+02)
 
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 2 planar dihedral(s), 0 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 5 | backx | 0 | 0 | 0 | no | Dihedral(H3-Si0-O2-Si1) = -180.0° (aromatic/baseline) |
+| 6 | backx, severe-dq | 1 | 0 | 0 | YES | Angle(Si0-O2-Si1) = 177.3° |
+| 7 | pinv | 1 | 0 | 0 | YES | Angle(Si0-O2-Si1) = 179.9° |
+
+**Verdict:** 2 of 3 warning step(s) coincide with a new planar/linear event; the remainder fired on a baseline geometry.
+
+
 ## birkholz/inosine_cation
 
 *severe back-xform RMS(dq) at step 11*
 
-Steps: 15, converged: False, wall: 3.1s.
+Steps: 15, converged: False, wall: 3.5s.
 
 ### Per-step pinv-gap summary
 
-| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals |
-|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 86 | 7.08e+12 | 1.31e+01 | 1.00e-30 | 0 | 0 |
-| 2 | 86 | 6.94e+12 | 1.35e+01 | 1.00e-30 | 0 | 0 |
-| 3 | 86 | 7.72e+12 | 1.39e+01 | 1.00e-30 | 0 | 0 |
-| 4 | 86 | 7.13e+12 | 1.39e+01 | 1.00e-30 | 0 | 0 |
-| 5 | 86 | 6.52e+12 | 1.39e+01 | 1.00e-30 | 0 | 0 |
-| 6 | 86 | 5.69e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 |
-| 7 | 86 | 7.54e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 |
-| 8 | 86 | 7.07e+12 | 1.39e+01 | 1.00e-30 | 0 | 0 |
-| 9 | 86 | 7.60e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 |
-| 10 | 86 | 7.66e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 |
-| 11 | 86 | 6.57e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 |
-| 12 | 86 | 7.64e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 |
-| 13 | 86 | 7.29e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 |
-| 14 | 86 | 7.55e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 |
-| 15 | 86 | 8.74e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 |
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 86 | 7.08e+12 | 1.31e+01 | 1.00e-30 | 0 | 0 | 44 | 6 |
+| 2 | 86 | 6.94e+12 | 1.35e+01 | 1.00e-30 | 0 | 0 | 43 | 6 |
+| 3 | 86 | 7.72e+12 | 1.39e+01 | 1.00e-30 | 0 | 0 | 43 | 6 |
+| 4 | 86 | 7.13e+12 | 1.39e+01 | 1.00e-30 | 0 | 0 | 40 | 6 |
+| 5 | 86 | 6.52e+12 | 1.39e+01 | 1.00e-30 | 0 | 0 | 37 | 7 |
+| 6 | 86 | 5.69e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 | 41 | 7 |
+| 7 | 86 | 7.54e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 | 38 | 7 |
+| 8 | 86 | 7.07e+12 | 1.39e+01 | 1.00e-30 | 0 | 0 | 43 | 7 |
+| 9 | 86 | 7.60e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 | 42 | 7 |
+| 10 | 86 | 7.66e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 | 43 | 7 |
+| 11 | 86 | 6.57e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 42 | 7 |
+| 12 | 86 | 7.64e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 40 | 7 |
+| 13 | 86 | 7.29e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 | 44 | 7 |
+| 14 | 86 | 7.55e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 | 44 | 7 |
+| 15 | 86 | 8.74e+12 | 1.40e+01 | 1.00e-30 | 0 | 0 | 41 | 7 |
 
 No step recorded a pinv gap value below `1e8` - the natural redundancy boundary is well-separated throughout the trajectory, and `Math.pinv` would never log a warning for this molecule.
+
+
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 44 planar dihedral(s), 6 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 11 | backx, severe-dq | 0 | 5 | 1 | YES | NEW Dihedral(C4-C0-C13-O16) = 177.5° (trans) |
+
+**Verdict:** every one of the 1 warning step(s) coincides with at least one planar/linear event new vs step 1 (or a near-linear angle).
 
 
 ## birkholz/maltose
 
 *severe back-xform + saddle pass at steps 27/30*
 
-Steps: 35, converged: False, wall: 8.8s.
+Steps: 35, converged: False, wall: 10.1s.
 
 ### Per-step pinv-gap summary
 
-| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals |
-|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 128 | 3.80e+12 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 2 | 128 | 2.94e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 3 | 128 | 3.91e+12 | 1.05e+01 | 1.00e-30 | 0 | 0 |
-| 4 | 128 | 3.76e+12 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 5 | 128 | 3.56e+12 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 6 | 128 | 2.90e+12 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 7 | 128 | 3.08e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 8 | 128 | 3.14e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 9 | 128 | 3.13e+12 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 10 | 128 | 2.35e+12 | 1.09e+01 | 1.00e-30 | 0 | 0 |
-| 11 | 128 | 3.07e+12 | 1.10e+01 | 1.00e-30 | 0 | 0 |
-| 12 | 128 | 3.26e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 13 | 128 | 2.97e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 14 | 128 | 3.46e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 15 | 128 | 2.92e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 16 | 128 | 3.43e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 17 | 128 | 2.96e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 18 | 128 | 2.67e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 19 | 128 | 2.89e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 20 | 128 | 2.86e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 21 | 128 | 3.61e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 22 | 128 | 3.17e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 23 | 128 | 3.54e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 24 | 128 | 2.81e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 25 | 128 | 2.84e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 26 | 128 | 3.19e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 27 | 128 | 3.38e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 28 | 128 | 3.04e+12 | 1.18e+01 | 1.00e-30 | 0 | 0 |
-| 29 | 128 | 3.42e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 30 | 128 | 3.70e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 31 | 128 | 4.43e+12 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 32 | 128 | 3.27e+12 | 1.13e+01 | 1.00e-30 | 0 | 0 |
-| 33 | 128 | 3.78e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 34 | 128 | 3.68e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
-| 35 | 128 | 3.85e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 |
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 128 | 3.80e+12 | 1.07e+01 | 1.00e-30 | 0 | 0 | 26 | 0 |
+| 2 | 128 | 2.94e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 | 26 | 0 |
+| 3 | 128 | 3.91e+12 | 1.05e+01 | 1.00e-30 | 0 | 0 | 20 | 0 |
+| 4 | 128 | 3.76e+12 | 1.03e+01 | 1.00e-30 | 0 | 0 | 15 | 0 |
+| 5 | 128 | 3.56e+12 | 1.03e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 6 | 128 | 2.90e+12 | 1.04e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 7 | 128 | 3.08e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 | 12 | 0 |
+| 8 | 128 | 3.14e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 9 | 128 | 3.13e+12 | 1.07e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 10 | 128 | 2.35e+12 | 1.09e+01 | 1.00e-30 | 0 | 0 | 9 | 0 |
+| 11 | 128 | 3.07e+12 | 1.10e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 12 | 128 | 3.26e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 | 10 | 0 |
+| 13 | 128 | 2.97e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 | 9 | 0 |
+| 14 | 128 | 3.46e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 15 | 128 | 2.92e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 | 10 | 0 |
+| 16 | 128 | 3.43e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 | 14 | 0 |
+| 17 | 128 | 2.96e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 | 10 | 0 |
+| 18 | 128 | 2.67e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 | 9 | 0 |
+| 19 | 128 | 2.89e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 9 | 0 |
+| 20 | 128 | 2.86e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 9 | 0 |
+| 21 | 128 | 3.61e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 8 | 0 |
+| 22 | 128 | 3.17e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 10 | 0 |
+| 23 | 128 | 3.54e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 8 | 0 |
+| 24 | 128 | 2.81e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 8 | 0 |
+| 25 | 128 | 2.84e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 8 | 0 |
+| 26 | 128 | 3.19e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 8 | 0 |
+| 27 | 128 | 3.38e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 8 | 0 |
+| 28 | 128 | 3.04e+12 | 1.18e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 29 | 128 | 3.42e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 9 | 0 |
+| 30 | 128 | 3.70e+12 | 1.11e+01 | 1.00e-30 | 0 | 0 | 8 | 0 |
+| 31 | 128 | 4.43e+12 | 1.04e+01 | 1.00e-30 | 0 | 0 | 7 | 0 |
+| 32 | 128 | 3.27e+12 | 1.13e+01 | 1.00e-30 | 0 | 0 | 7 | 0 |
+| 33 | 128 | 3.78e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 8 | 0 |
+| 34 | 128 | 3.68e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 7 | 0 |
+| 35 | 128 | 3.85e+12 | 1.12e+01 | 1.00e-30 | 0 | 0 | 6 | 0 |
 
 No step recorded a pinv gap value below `1e8` - the natural redundancy boundary is well-separated throughout the trajectory, and `Math.pinv` would never log a warning for this molecule.
+
+
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 26 planar dihedral(s), 0 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 27 | backx, neg-eig, severe-dq | 0 | 4 | 0 | YES | NEW Dihedral(H6-C1-C2-O10) = -177.3° (trans) |
+| 30 | backx, neg-eig, severe-dq | 0 | 4 | 0 | YES | NEW Dihedral(H6-C1-C2-O10) = -175.9° (trans) |
+| 31 | neg-eig | 0 | 4 | 0 | YES | NEW Dihedral(C11-C13-C24-H26) = -176.8° (trans) |
+
+**Verdict:** every one of the 3 warning step(s) coincides with at least one planar/linear event new vs step 1 (or a near-linear angle).
 
 
 ## birkholz/raffinose
 
 *heavy back-xform + non-converger (steps 42-49)*
 
-Steps: 55, converged: False, wall: 20.5s.
+Steps: 55, converged: False, wall: 25.0s.
 
 ### Per-step pinv-gap summary
 
-| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals |
-|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 191 | 7.03e+11 | 3.95e+01 | 1.00e-30 | 0 | 0 |
-| 2 | 191 | 4.64e+11 | 3.26e+01 | 1.00e-30 | 0 | 0 |
-| 3 | 191 | 8.79e+11 | 2.20e+01 | 1.00e-30 | 0 | 0 |
-| 4 | 191 | 7.39e+11 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 5 | 191 | 9.34e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 6 | 191 | 8.13e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 7 | 191 | 8.17e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 8 | 191 | 8.77e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 9 | 191 | 8.21e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 10 | 191 | 9.17e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 11 | 191 | 7.83e+11 | 1.05e+01 | 1.00e-30 | 0 | 0 |
-| 12 | 191 | 8.90e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 13 | 191 | 8.49e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 14 | 191 | 9.64e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 15 | 191 | 9.03e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 16 | 191 | 8.77e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 17 | 191 | 9.77e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 18 | 191 | 9.69e+11 | 1.05e+01 | 1.00e-30 | 0 | 0 |
-| 19 | 191 | 9.31e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 20 | 191 | 9.50e+11 | 1.05e+01 | 1.00e-30 | 0 | 0 |
-| 21 | 191 | 9.74e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 22 | 191 | 9.58e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 23 | 191 | 9.18e+11 | 1.05e+01 | 1.00e-30 | 0 | 0 |
-| 24 | 191 | 1.09e+12 | 1.05e+01 | 1.00e-30 | 0 | 0 |
-| 25 | 191 | 9.00e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 26 | 191 | 9.25e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 27 | 191 | 9.02e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 28 | 191 | 9.83e+11 | 1.08e+01 | 1.00e-30 | 0 | 0 |
-| 29 | 191 | 9.89e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 30 | 191 | 9.41e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 31 | 191 | 8.63e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 32 | 191 | 1.03e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 33 | 191 | 1.13e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 34 | 191 | 1.00e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 35 | 191 | 8.44e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 36 | 191 | 1.03e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 37 | 191 | 9.58e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 38 | 191 | 9.46e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 |
-| 39 | 191 | 9.15e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 40 | 191 | 8.41e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 41 | 191 | 9.39e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 42 | 191 | 1.15e+12 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 43 | 191 | 1.10e+12 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 44 | 191 | 9.57e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 45 | 191 | 1.01e+12 | 1.07e+01 | 1.00e-30 | 0 | 0 |
-| 46 | 191 | 7.37e+11 | 1.08e+01 | 1.00e-30 | 0 | 0 |
-| 47 | 191 | 4.68e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 48 | 191 | 7.36e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 |
-| 49 | 191 | 5.52e+11 | 1.11e+01 | 1.00e-30 | 0 | 0 |
-| 50 | 191 | 8.55e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 |
-| 51 | 191 | 8.93e+11 | 1.08e+01 | 1.00e-30 | 0 | 0 |
-| 52 | 191 | 8.17e+11 | 1.08e+01 | 1.00e-30 | 0 | 0 |
-| 53 | 191 | 7.54e+11 | 1.09e+01 | 1.00e-30 | 0 | 0 |
-| 54 | 191 | 6.92e+11 | 1.10e+01 | 1.00e-30 | 0 | 0 |
-| 55 | 191 | 7.25e+11 | 1.09e+01 | 1.00e-30 | 0 | 0 |
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 191 | 7.03e+11 | 3.95e+01 | 1.00e-30 | 0 | 0 | 38 | 0 |
+| 2 | 191 | 4.64e+11 | 3.26e+01 | 1.00e-30 | 0 | 0 | 36 | 0 |
+| 3 | 191 | 8.79e+11 | 2.20e+01 | 1.00e-30 | 0 | 0 | 38 | 0 |
+| 4 | 191 | 7.39e+11 | 1.59e+01 | 1.00e-30 | 0 | 0 | 34 | 0 |
+| 5 | 191 | 9.34e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 32 | 0 |
+| 6 | 191 | 8.13e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 31 | 0 |
+| 7 | 191 | 8.17e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 | 26 | 0 |
+| 8 | 191 | 8.77e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 | 27 | 0 |
+| 9 | 191 | 8.21e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 | 26 | 0 |
+| 10 | 191 | 9.17e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 | 25 | 0 |
+| 11 | 191 | 7.83e+11 | 1.05e+01 | 1.00e-30 | 0 | 0 | 21 | 0 |
+| 12 | 191 | 8.90e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 | 18 | 0 |
+| 13 | 191 | 8.49e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 | 14 | 0 |
+| 14 | 191 | 9.64e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 15 | 191 | 9.03e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 16 | 191 | 8.77e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 | 12 | 0 |
+| 17 | 191 | 9.77e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 18 | 191 | 9.69e+11 | 1.05e+01 | 1.00e-30 | 0 | 0 | 14 | 0 |
+| 19 | 191 | 9.31e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 16 | 0 |
+| 20 | 191 | 9.50e+11 | 1.05e+01 | 1.00e-30 | 0 | 0 | 17 | 0 |
+| 21 | 191 | 9.74e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 17 | 0 |
+| 22 | 191 | 9.58e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 16 | 0 |
+| 23 | 191 | 9.18e+11 | 1.05e+01 | 1.00e-30 | 0 | 0 | 15 | 0 |
+| 24 | 191 | 1.09e+12 | 1.05e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 25 | 191 | 9.00e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 12 | 0 |
+| 26 | 191 | 9.25e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 27 | 191 | 9.02e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 | 12 | 0 |
+| 28 | 191 | 9.83e+11 | 1.08e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 29 | 191 | 9.89e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 | 12 | 0 |
+| 30 | 191 | 9.41e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 31 | 191 | 8.63e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 32 | 191 | 1.03e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 | 14 | 0 |
+| 33 | 191 | 1.13e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 | 18 | 0 |
+| 34 | 191 | 1.00e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 | 18 | 0 |
+| 35 | 191 | 8.44e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 17 | 0 |
+| 36 | 191 | 1.03e+12 | 1.06e+01 | 1.00e-30 | 0 | 0 | 16 | 0 |
+| 37 | 191 | 9.58e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 15 | 0 |
+| 38 | 191 | 9.46e+11 | 1.06e+01 | 1.00e-30 | 0 | 0 | 15 | 0 |
+| 39 | 191 | 9.15e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 | 14 | 0 |
+| 40 | 191 | 8.41e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 | 16 | 0 |
+| 41 | 191 | 9.39e+11 | 1.07e+01 | 1.00e-30 | 0 | 0 | 14 | 0 |
+| 42 | 191 | 1.15e+12 | 1.07e+01 | 1.00e-30 | 0 | 0 | 14 | 0 |
+| 43 | 191 | 1.10e+12 | 1.03e+01 | 1.00e-30 | 0 | 0 | 15 | 0 |
+| 44 | 191 | 9.57e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 | 17 | 0 |
+| 45 | 191 | 1.01e+12 | 1.07e+01 | 1.00e-30 | 0 | 0 | 17 | 0 |
+| 46 | 191 | 7.37e+11 | 1.08e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 47 | 191 | 4.68e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 | 15 | 0 |
+| 48 | 191 | 7.36e+11 | 1.03e+01 | 1.00e-30 | 0 | 0 | 15 | 0 |
+| 49 | 191 | 5.52e+11 | 1.11e+01 | 1.00e-30 | 0 | 0 | 14 | 0 |
+| 50 | 191 | 8.55e+11 | 1.04e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 51 | 191 | 8.93e+11 | 1.08e+01 | 1.00e-30 | 0 | 0 | 12 | 0 |
+| 52 | 191 | 8.17e+11 | 1.08e+01 | 1.00e-30 | 0 | 0 | 11 | 0 |
+| 53 | 191 | 7.54e+11 | 1.09e+01 | 1.00e-30 | 0 | 0 | 10 | 0 |
+| 54 | 191 | 6.92e+11 | 1.10e+01 | 1.00e-30 | 0 | 0 | 13 | 0 |
+| 55 | 191 | 7.25e+11 | 1.09e+01 | 1.00e-30 | 0 | 0 | 12 | 0 |
 
 No step recorded a pinv gap value below `1e8` - the natural redundancy boundary is well-separated throughout the trajectory, and `Math.pinv` would never log a warning for this molecule.
+
+
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 38 planar dihedral(s), 0 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 42 | backx, neg-eig, severe-dq | 0 | 7 | 0 | YES | NEW Dihedral(C4-C0-O44-H45) = -1.9° (cis) |
+| 43 | backx, severe-dq | 0 | 9 | 0 | YES | NEW Dihedral(C4-C0-O44-H45) = -4.0° (cis) |
+| 45 | neg-eig | 0 | 8 | 0 | YES | NEW Dihedral(O10-C2-C3-H8) = 175.8° (trans) |
+| 46 | backx, neg-eig, severe-dq | 0 | 5 | 0 | YES | NEW Dihedral(O10-C2-C3-H8) = 176.4° (trans) |
+| 47 | backx, neg-eig, severe-dq | 0 | 5 | 0 | YES | NEW Dihedral(O21-C14-C17-H20) = -177.4° (trans) |
+| 48 | backx, neg-eig, severe-dq | 0 | 6 | 0 | YES | NEW Dihedral(O10-C2-C3-H8) = 176.3° (trans) |
+| 49 | backx, severe-dq | 0 | 6 | 0 | YES | NEW Dihedral(O21-C14-C17-H20) = -178.9° (trans) |
+
+**Verdict:** every one of the 7 warning step(s) coincides with at least one planar/linear event new vs step 1 (or a near-linear angle).
 
 
 ## baker/caffeine
 
 *control: 43 neg-eigval events; not coord-singular*
 
-Steps: 55, converged: False, wall: 9.3s.
+Steps: 55, converged: False, wall: 8.9s.
 
 ### Per-step pinv-gap summary
 
-| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals |
-|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 65 | 7.09e+12 | 1.58e+01 | 1.00e-30 | 0 | 0 |
-| 2 | 65 | 1.45e+13 | 1.57e+01 | 1.00e-30 | 0 | 0 |
-| 3 | 65 | 1.20e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 4 | 65 | 1.14e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 5 | 65 | 1.30e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 6 | 65 | 1.24e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 7 | 65 | 1.23e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 8 | 65 | 1.22e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 9 | 65 | 1.44e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 10 | 65 | 1.70e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 11 | 65 | 1.32e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 12 | 65 | 1.59e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 13 | 65 | 1.02e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 14 | 65 | 1.54e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 15 | 65 | 1.58e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 16 | 65 | 1.51e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 17 | 65 | 1.64e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 18 | 65 | 1.53e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 19 | 65 | 1.35e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 20 | 65 | 1.27e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 21 | 65 | 1.16e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 22 | 65 | 1.55e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 23 | 65 | 1.46e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 24 | 65 | 1.46e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 25 | 65 | 1.04e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 26 | 65 | 1.25e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 27 | 65 | 1.09e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 28 | 65 | 1.38e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 29 | 65 | 1.23e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 30 | 65 | 1.02e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 31 | 65 | 1.49e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 32 | 65 | 1.69e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 33 | 65 | 1.25e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 34 | 65 | 1.24e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 35 | 65 | 1.50e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 36 | 65 | 1.46e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 37 | 65 | 1.47e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 38 | 65 | 1.25e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 39 | 65 | 1.10e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 40 | 65 | 1.41e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 41 | 65 | 1.48e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 42 | 65 | 1.30e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 43 | 65 | 1.22e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 44 | 65 | 1.42e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 45 | 65 | 1.30e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 46 | 65 | 1.44e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 47 | 65 | 1.14e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 48 | 65 | 1.33e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 49 | 65 | 1.23e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 50 | 65 | 1.22e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 51 | 65 | 1.35e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 52 | 65 | 1.20e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 53 | 65 | 1.30e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 54 | 65 | 1.34e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
-| 55 | 65 | 1.50e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 |
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 65 | 7.09e+12 | 1.58e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 2 | 65 | 1.45e+13 | 1.57e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 3 | 65 | 1.20e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 4 | 65 | 1.14e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 5 | 65 | 1.30e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 6 | 65 | 1.24e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 7 | 65 | 1.23e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 8 | 65 | 1.22e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 9 | 65 | 1.44e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 10 | 65 | 1.70e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 11 | 65 | 1.32e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 12 | 65 | 1.59e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 13 | 65 | 1.02e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 14 | 65 | 1.54e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 15 | 65 | 1.58e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 16 | 65 | 1.51e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 17 | 65 | 1.64e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 18 | 65 | 1.53e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 19 | 65 | 1.35e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 20 | 65 | 1.27e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 21 | 65 | 1.16e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 22 | 65 | 1.55e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 23 | 65 | 1.46e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 24 | 65 | 1.46e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 25 | 65 | 1.04e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 26 | 65 | 1.25e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 27 | 65 | 1.09e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 28 | 65 | 1.38e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 29 | 65 | 1.23e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 30 | 65 | 1.02e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 31 | 65 | 1.49e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 32 | 65 | 1.69e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 33 | 65 | 1.25e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 34 | 65 | 1.24e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 35 | 65 | 1.50e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 36 | 65 | 1.46e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 37 | 65 | 1.47e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 38 | 65 | 1.25e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 39 | 65 | 1.10e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 40 | 65 | 1.41e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 41 | 65 | 1.48e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 42 | 65 | 1.30e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 43 | 65 | 1.22e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 44 | 65 | 1.42e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 45 | 65 | 1.30e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 46 | 65 | 1.44e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 47 | 65 | 1.14e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 48 | 65 | 1.33e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 49 | 65 | 1.23e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 50 | 65 | 1.22e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 51 | 65 | 1.35e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 52 | 65 | 1.20e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 53 | 65 | 1.30e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 54 | 65 | 1.34e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
+| 55 | 65 | 1.50e+13 | 1.59e+01 | 1.00e-30 | 0 | 0 | 42 | 8 |
 
 No step recorded a pinv gap value below `1e8` - the natural redundancy boundary is well-separated throughout the trajectory, and `Math.pinv` would never log a warning for this molecule.
+
+
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 42 planar dihedral(s), 8 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 27 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 30 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 33 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 35 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 36 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 38 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 39 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 41 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 45 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 47 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 49 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 51 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 52 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+| 53 | neg-eig | 0 | 0 | 0 | no | Dihedral(C8-N2-C6-C7) = -0.0° (aromatic/baseline) |
+
+**Verdict:** none of the 14 warning step(s) coincides with a new planar/linear event - the warnings here are not coordinate-singularity events.
+
+
+## birkholz/avobenzone
+
+*neg-eig only: 4 events at steps 14/17/20/49*
+
+Steps: 55, converged: False, wall: 14.4s.
+
+### Per-step pinv-gap summary
+
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 128 | 5.26e+11 | 1.40e+01 | 1.00e-30 | 0 | 0 | 63 | 14 |
+| 2 | 128 | 5.36e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 63 | 14 |
+| 3 | 128 | 6.21e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 4 | 128 | 5.19e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 63 | 14 |
+| 5 | 128 | 5.16e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 66 | 14 |
+| 6 | 128 | 6.08e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 67 | 14 |
+| 7 | 128 | 5.89e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 69 | 14 |
+| 8 | 128 | 6.04e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 69 | 14 |
+| 9 | 128 | 5.62e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 69 | 14 |
+| 10 | 128 | 4.84e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 69 | 14 |
+| 11 | 128 | 6.02e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 70 | 14 |
+| 12 | 128 | 6.73e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 72 | 14 |
+| 13 | 128 | 6.03e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 73 | 14 |
+| 14 | 128 | 5.70e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 71 | 14 |
+| 15 | 128 | 6.19e+11 | 1.43e+01 | 1.00e-30 | 0 | 0 | 70 | 14 |
+| 16 | 128 | 6.11e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 70 | 14 |
+| 17 | 128 | 5.72e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 66 | 14 |
+| 18 | 128 | 5.37e+11 | 1.43e+01 | 1.00e-30 | 0 | 0 | 64 | 14 |
+| 19 | 128 | 4.83e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 66 | 14 |
+| 20 | 128 | 6.01e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 65 | 14 |
+| 21 | 128 | 5.94e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 66 | 14 |
+| 22 | 128 | 6.34e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 66 | 14 |
+| 23 | 128 | 6.04e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 63 | 14 |
+| 24 | 128 | 6.90e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 64 | 14 |
+| 25 | 128 | 8.48e+11 | 1.42e+01 | 1.00e-30 | 0 | 0 | 60 | 14 |
+| 26 | 128 | 1.06e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 60 | 14 |
+| 27 | 128 | 1.01e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 28 | 128 | 8.43e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 29 | 128 | 8.15e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 30 | 128 | 1.06e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 31 | 128 | 8.85e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 60 | 14 |
+| 32 | 128 | 9.84e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 33 | 128 | 9.87e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 34 | 128 | 9.72e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 35 | 128 | 1.41e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 36 | 128 | 1.27e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 37 | 128 | 1.19e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 38 | 128 | 1.07e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 60 | 14 |
+| 39 | 128 | 1.11e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 40 | 128 | 7.42e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 41 | 128 | 9.71e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 42 | 128 | 1.01e+12 | 1.41e+01 | 1.00e-30 | 0 | 0 | 63 | 14 |
+| 43 | 128 | 8.60e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 63 | 14 |
+| 44 | 128 | 7.39e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 65 | 14 |
+| 45 | 128 | 8.46e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 46 | 128 | 8.73e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 47 | 128 | 7.90e+11 | 1.40e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 48 | 128 | 6.15e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 49 | 128 | 6.87e+11 | 1.41e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 50 | 128 | 6.59e+11 | 1.38e+01 | 1.00e-30 | 0 | 0 | 40 | 14 |
+| 51 | 128 | 6.49e+11 | 1.40e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 52 | 128 | 5.71e+11 | 1.40e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+| 53 | 128 | 6.06e+11 | 1.40e+01 | 1.00e-30 | 0 | 0 | 58 | 14 |
+| 54 | 128 | 6.47e+11 | 1.40e+01 | 1.00e-30 | 0 | 0 | 62 | 14 |
+| 55 | 128 | 5.60e+11 | 1.40e+01 | 1.00e-30 | 0 | 0 | 61 | 14 |
+
+No step recorded a pinv gap value below `1e8` - the natural redundancy boundary is well-separated throughout the trajectory, and `Math.pinv` would never log a warning for this molecule.
+
+
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 63 planar dihedral(s), 14 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 14 | neg-eig | 0 | 10 | 0 | YES | NEW Dihedral(C8-C12-O27-C28) = -1.3° (cis) |
+| 17 | neg-eig | 0 | 11 | 0 | YES | NEW Dihedral(C8-C12-O27-C28) = 0.1° (cis) |
+| 20 | neg-eig | 0 | 10 | 0 | YES | NEW Dihedral(C8-C12-O27-C28) = 1.1° (cis) |
+| 49 | neg-eig | 0 | 10 | 0 | YES | NEW Dihedral(C8-C12-O27-C28) = 0.2° (cis) |
+
+**Verdict:** every one of the 4 warning step(s) coincides with at least one planar/linear event new vs step 1 (or a near-linear angle).
+
+
+## birkholz/codeine
+
+*neg-eig only: 2 events at steps 15/18*
+
+Steps: 25, converged: False, wall: 7.3s.
+
+### Per-step pinv-gap summary
+
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 122 | 6.94e+12 | 1.66e+01 | 1.00e-30 | 0 | 0 | 26 | 8 |
+| 2 | 122 | 3.79e+12 | 1.65e+01 | 1.00e-30 | 0 | 0 | 28 | 8 |
+| 3 | 122 | 7.55e+12 | 1.67e+01 | 1.00e-30 | 0 | 0 | 28 | 8 |
+| 4 | 122 | 7.47e+12 | 1.69e+01 | 1.00e-30 | 0 | 0 | 28 | 8 |
+| 5 | 122 | 7.55e+12 | 1.66e+01 | 1.00e-30 | 0 | 0 | 24 | 8 |
+| 6 | 122 | 6.39e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 22 | 8 |
+| 7 | 122 | 8.19e+12 | 1.62e+01 | 1.00e-30 | 0 | 0 | 26 | 8 |
+| 8 | 122 | 7.01e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 27 | 8 |
+| 9 | 122 | 8.14e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 27 | 8 |
+| 10 | 122 | 8.12e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 28 | 8 |
+| 11 | 122 | 4.74e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 28 | 8 |
+| 12 | 122 | 7.06e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 27 | 8 |
+| 13 | 122 | 7.17e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 28 | 8 |
+| 14 | 122 | 5.26e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 30 | 8 |
+| 15 | 122 | 7.51e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 31 | 8 |
+| 16 | 122 | 8.02e+12 | 1.60e+01 | 1.00e-30 | 0 | 0 | 25 | 8 |
+| 17 | 122 | 6.12e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 33 | 8 |
+| 18 | 122 | 7.48e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 32 | 8 |
+| 19 | 122 | 5.50e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 22 | 8 |
+| 20 | 122 | 7.76e+12 | 1.62e+01 | 1.00e-30 | 0 | 0 | 34 | 8 |
+| 21 | 122 | 5.77e+12 | 1.62e+01 | 1.00e-30 | 0 | 0 | 31 | 8 |
+| 22 | 122 | 8.76e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 30 | 8 |
+| 23 | 122 | 5.36e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 31 | 8 |
+| 24 | 122 | 6.72e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 31 | 8 |
+| 25 | 122 | 8.30e+12 | 1.63e+01 | 1.00e-30 | 0 | 0 | 32 | 8 |
+
+No step recorded a pinv gap value below `1e8` - the natural redundancy boundary is well-separated throughout the trajectory, and `Math.pinv` would never log a warning for this molecule.
+
+
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 26 planar dihedral(s), 8 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 15 | neg-eig | 0 | 14 | 0 | YES | NEW Dihedral(C5-C0-C1-C2) = 4.2° (cis) |
+| 18 | neg-eig | 0 | 16 | 0 | YES | NEW Dihedral(C5-C0-C1-C2) = 2.6° (cis) |
+
+**Verdict:** every one of the 2 warning step(s) coincides with at least one planar/linear event new vs step 1 (or a near-linear angle).
+
+
+## baker/methylamine
+
+*neg-eig only: 4 events at steps 5/7/8/9*
+
+Steps: 18, converged: True, wall: 0.4s.
+
+### Per-step pinv-gap summary
+
+| step | pinv_gap_idx | gap | sv_max | sv_min | #near-lin angles | #near-lin dihedrals | #near-planar dihedrals | #planar sp3 |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 14 | 2.57e+14 | 6.89e+00 | 1.00e-30 | 0 | 0 | 2 | 1 |
+| 2 | 14 | 8.21e+14 | 6.88e+00 | 1.00e-30 | 0 | 0 | 2 | 1 |
+| 3 | 14 | 5.71e+14 | 6.82e+00 | 1.00e-30 | 0 | 0 | 2 | 1 |
+| 4 | 14 | 4.60e+14 | 6.79e+00 | 1.00e-30 | 0 | 0 | 2 | 1 |
+| 5 | 14 | 7.02e+14 | 6.77e+00 | 1.00e-30 | 0 | 0 | 2 | 1 |
+| 6 | 14 | 6.49e+14 | 7.23e+00 | 1.00e-30 | 0 | 0 | 0 | 1 |
+| 7 | 14 | 4.75e+14 | 6.83e+00 | 1.00e-30 | 0 | 0 | 2 | 1 |
+| 8 | 14 | 4.16e+14 | 6.72e+00 | 1.00e-30 | 0 | 0 | 0 | 1 |
+| 9 | 14 | 7.77e+14 | 6.58e+00 | 1.00e-30 | 0 | 0 | 0 | 0 |
+| 10 | 14 | 6.86e+14 | 5.72e+00 | 1.00e-30 | 0 | 0 | 0 | 0 |
+| 11 | 14 | 5.29e+14 | 6.00e+00 | 1.00e-30 | 0 | 0 | 0 | 0 |
+| 12 | 14 | 7.64e+14 | 5.71e+00 | 1.00e-30 | 0 | 0 | 0 | 0 |
+| 13 | 14 | 4.66e+14 | 5.76e+00 | 1.00e-30 | 0 | 0 | 0 | 0 |
+| 14 | 14 | 9.08e+14 | 5.73e+00 | 1.00e-30 | 0 | 0 | 0 | 0 |
+| 15 | 14 | 7.58e+14 | 5.70e+00 | 1.00e-30 | 0 | 0 | 0 | 0 |
+| 16 | 14 | 1.18e+15 | 5.67e+00 | 1.00e-30 | 0 | 0 | 2 | 0 |
+| 17 | 14 | 7.14e+14 | 5.68e+00 | 1.00e-30 | 0 | 0 | 2 | 0 |
+| 18 | 14 | 6.80e+14 | 5.68e+00 | 1.00e-30 | 0 | 0 | 2 | 0 |
+
+No step recorded a pinv gap value below `1e8` - the natural redundancy boundary is well-separated throughout the trajectory, and `Math.pinv` would never log a warning for this molecule.
+
+
+### Warning-step / geometry correlation
+
+For each step where `benchmark_trajectory_check.py`'s log scan would record a warning, the columns below report the count of geometric degeneracies at that step. `near_lin_ang` counts angles > 175°. `new_planar_dih` is the number of dihedrals within 5° of 0°/180° that were NOT already planar at step 1 (subtracting the aromatic-ring baseline). `new_planar_sp3` is the number of three-coord heavy centres whose substituent-angle sum exceeds 355° and were not already planar at step 1. The "geom flag" column is YES if at least one of those three is nonzero.
+
+Step-1 baseline: 2 planar dihedral(s), 1 planar sp3 centre(s).
+
+| step | warning kinds | n_near_lin_ang | new_planar_dih | new_planar_sp3 | geom flag | example |
+|---:|---|---:|---:|---:|---|---|
+| 5 | neg-eig | 0 | 0 | 0 | no | Dihedral(H2-N0-C1-H3) = 179.4° (aromatic/baseline) |
+| 7 | neg-eig | 0 | 0 | 0 | no | Dihedral(H2-N0-C1-H3) = 177.5° (aromatic/baseline) |
+| 8 | neg-eig | 0 | 0 | 0 | no | centre N0 planar (aromatic/baseline) |
+| 9 | neg-eig | 0 | 0 | 0 | no | - |
+
+**Verdict:** none of the 4 warning step(s) coincides with a new planar/linear event - the warnings here are not coordinate-singularity events.
 
 
 ## Conclusions
@@ -487,7 +800,11 @@ Two distinct mechanisms produce the `Pseudoinverse gap of only:` warning:
 
 2. **Rank drop** (allene). A symmetry-imposed linear backbone (`C=C=C`) means rotation about that axis genuinely is not a DOF, so the B-matrix has one extra near-zero singular value. The pinv gap fires at the natural-redundancy index but the gap value is small (~10³-10⁷) and a real H-C-H angle DOF gets truncated alongside the missing rotational mode.
 
-The other flagged cases (inosine_cation, maltose, raffinose, caffeine) have pinv gap values uniformly above `1e11` and never trigger the warning. Their pathologies are different: saddle-pass attempts (negative eigenvalues + huge predicted energy change) for maltose/raffinose, multivalued Cartesian↔internal map at one step for inosine_cation, and a confusing PES for caffeine. None of these implicates `Math.pinv` truncation.
+The other flagged cases (inosine_cation, maltose, raffinose, caffeine, plus the neg-eig-only cases avobenzone, codeine, methylamine) have pinv gap values uniformly above `1e11` and never trigger the pinv warning. Tracking dihedrals within 5° of 0°/180° and three-coord centres within 5° of their substituent plane (subtracting the step-1 aromatic baseline) splits these into two groups:
+
+- **Planar-dihedral coincidence** (inosine_cation, maltose, raffinose, avobenzone, codeine): every step that emitted a back-xform, severe-dq, or neg-eig warning had at least one dihedral cross into the 5°-of-planar region between the starting geometry and that step. On raffinose the offenders are `Dihedral(C4-C0-O44-H45)` and `Dihedral(O10-C2-C3-H8)` cycling through 0°/180° as the sugar ring puckers; on maltose it is `Dihedral(H6-C1-C2-O10)` going trans; on avobenzone it is `Dihedral(C8-C12-O27-C28)` flipping through cis on every neg-eig step (14, 17, 20, 49). These warnings are the same class of coordinate-singularity event as the pinv@final cases - the back-transform Newton iteration just happens to absorb the gradient blow-up before the pinv truncation fires.
+
+- **PES topology, not coordinate singularity** (caffeine, methylamine): zero of the neg-eig warning steps coincided with a new planar event. Caffeine's 43 neg-eig events and methylamine's 4 are genuine BFGS spurious-unstable-mode events on a confusing PES region, not numerical breakdowns of the internal-coord representation.
 
 In every truncation case the geometric culprit is identifiable in one line:
 
@@ -496,3 +813,25 @@ In every truncation case the geometric culprit is identifiable in one line:
 | estradiol | `Angle(H37-C36-O40)` -> 179.66° | dihedral B-row inflated (`Dihedral(H37-C36-O40-C34)` and `-H41`) |
 | disilyl_ether | `Angle(Si0-O2-Si1)` -> 179.94° | six dihedrals `H?-Si?-O-Si?` B-row inflated to ~7.5e+02 |
 | allene | `Angle(C1-C0-C2)` -> 179.98° (symmetry) | rank drop; H-C-H angles get truncated instead |
+| inosine_cation | `Dihedral(C4-C0-C13-O16)` -> 177.5° | new trans-planar dihedral coincides with step-11 severe-dq |
+| maltose | `Dihedral(H6-C1-C2-O10)` -> ~177° | new trans dihedral on every severe-dq + neg-eig step (27/30/31) |
+| raffinose | `Dihedral(C4-C0-O44-H45)`, `Dihedral(O10-C2-C3-H8)`, `Dihedral(O21-C14-C17-H20)` -> ~0°/180° | sugar-ring puckering through planar configurations over steps 42-49 |
+| avobenzone | `Dihedral(C8-C12-O27-C28)` -> ~0° | aryl-ether C-O dihedral flipping cis on every neg-eig step (14/17/20/49) |
+| codeine | `Dihedral(C5-C0-C1-C2)` -> ~3° | ring dihedral going cis on the neg-eig steps (15/18) |
+| caffeine | none | 43 neg-eig events on a confusing PES; no new planar/linear event on any warning step |
+| methylamine | none | 4 neg-eig events; N inversion baseline-planar already, no new planar/linear event |
+
+### Planar/linear coincidence across all warning categories
+
+| case | warning steps w/ planar-or-linear flag | total warning steps | verdict |
+|---|---:|---:|---|
+| birkholz/estradiol | 6 | 6 | all planar/linear |
+| baker/allene | 9 | 9 | all planar/linear |
+| baker/disilyl_ether | 2 | 3 | partial |
+| birkholz/inosine_cation | 1 | 1 | all planar/linear |
+| birkholz/maltose | 3 | 3 | all planar/linear |
+| birkholz/raffinose | 7 | 7 | all planar/linear |
+| baker/caffeine | 0 | 14 | none planar/linear |
+| birkholz/avobenzone | 4 | 4 | all planar/linear |
+| birkholz/codeine | 2 | 2 | all planar/linear |
+| baker/methylamine | 0 | 4 | none planar/linear |


### PR DESCRIPTION
## Summary

Extends `experiments/microvariations/benchmark_internals_diag.py` with two per-step planarity metrics — near-planar dihedrals (within 5° of 0°/180°) and planar three-coord heavy centres (substituent angle sum > 355°) — and a warning-step / geometry correlation section. The 4 previously unexplained warning cases plus 3 fresh neg-eig-only cases (avobenzone, codeine, methylamine) are added.

By subtracting the step-1 set, the metric strips aromatic / sp2 baseline so what's left is coords that *become* planar during the trajectory.

## Findings

The new correlation table answers, for every step that the trajectory-warning sweep flagged on every case, whether a planar/linear event coincides with the warning.

| case | warning steps w/ planar-or-linear flag | total warning steps | verdict |
|---|---:|---:|---|
| birkholz/estradiol | 6 | 6 | all planar/linear |
| baker/allene | 9 | 9 | all planar/linear |
| baker/disilyl_ether | 2 | 3 | partial |
| birkholz/inosine_cation | 1 | 1 | all planar/linear |
| birkholz/maltose | 3 | 3 | all planar/linear |
| birkholz/raffinose | 7 | 7 | all planar/linear |
| baker/caffeine | 0 | 14 | none planar/linear |
| birkholz/avobenzone | 4 | 4 | all planar/linear |
| birkholz/codeine | 2 | 2 | all planar/linear |
| baker/methylamine | 0 | 4 | none planar/linear |

The split is clean. The "severe back-xform" and "neg-eig" categories — previously unexplained for half the cases — split into:

- **Planar-dihedral coincidence** (`inosine_cation`, `maltose`, `raffinose`, `avobenzone`, `codeine`): every warning step had at least one dihedral cross into 5°-of-planar between step 1 and that step. Raffinose: sugar-ring puckering through 0°/180° on `Dihedral(C4-C0-O44-H45)` and `Dihedral(O10-C2-C3-H8)`; maltose: `Dihedral(H6-C1-C2-O10)` going trans; avobenzone: aryl-ether `Dihedral(C8-C12-O27-C28)` flipping cis on every neg-eig step (14, 17, 20, 49). Same family as the pinv@final cases — back-xform Newton iteration just happens to absorb the gradient blow-up before pinv truncation fires.
- **PES topology, not coordinate singularity** (`caffeine`, `methylamine`): zero coincidences. Real BFGS-spurious-mode events on a confusing PES, not numerical breakdown of the internal-coord representation.

## Test plan

- [x] `scripts/check.sh` (flake8 / black / isort / pydocstyle / pytest 102 passed; sphinx step fails offline because of 403 fetching the intersphinx inventory, unrelated to this change)
- [x] Smoke run on the three pinv@final controls (estradiol / allene / disilyl_ether) — new metrics fire on the same steps the pre-existing per-step table already identified
- [x] Full run over all 10 cases (~75s wall) — `summary.md` regenerated and committed
- [ ] CI pass on the pushed branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gx8udysT5ei5vz5zEYSKbg)_