### PR TITLE
Make MopacSolver parse derivative rows robustly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `get_property` now raises a clear `KeyError` identifying the species and property when the requested datum is missing, instead of letting the call fail later with an opaque numpy error.
 - Lookup of species data by atomic number (rather than symbol) now works correctly.
+- `MopacSolver` now parses MOPAC derivative rows with variant column layouts and raises a clear error for truncated derivative blocks.
 
 ## [0.6.3] - 2021-02-22
 

--- a/src/berny/solvers.py
+++ b/src/berny/solvers.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterable, Iterator
 from typing import Any, Optional
 
 import numpy as np
@@ -55,6 +55,80 @@ def _mopac_keyword_line(method: str, charge: int, mult: int) -> str:
     return ' '.join(keywords)
 
 
+def _parse_float_token(token: str) -> float:
+    return float(token.replace('D', 'E').replace('d', 'e'))
+
+
+def _parse_mopac_energy(line: str) -> float:
+    tokens = line.replace('=', ' = ').split()
+    if '=' in tokens:
+        tokens = tokens[tokens.index('=') + 1 :]
+    for token in tokens:
+        try:
+            return _parse_float_token(token)
+        except ValueError:
+            pass
+    raise ValueError(f'could not parse MOPAC energy line: {line.strip()}')
+
+
+def _parse_mopac_gradient_value(line: str) -> float:
+    tokens = line.split()
+    if 'KCAL/ANGSTROM' in tokens:
+        tokens = tokens[: tokens.index('KCAL/ANGSTROM')]
+    for token in reversed(tokens):
+        try:
+            return _parse_float_token(token)
+        except ValueError:
+            pass
+    raise ValueError(f'could not parse MOPAC gradient line: {line.strip()}')
+
+
+def _read_mopac_gradient_value(
+    lines: Iterator[str], component_number: int, total_components: int
+) -> float:
+    for line in lines:
+        if 'ATOM' in line and 'CHEMICAL' in line:
+            break
+        if 'CARTESIAN' not in line:
+            continue
+        return _parse_mopac_gradient_value(line)
+    raise ValueError(
+        'MOPAC output ended before gradient component '
+        f'{component_number} of {total_components}'
+    )
+
+
+def _parse_mopac_output(
+    lines: Iterable[str], n_gradient_rows: int
+) -> tuple[float, FloatArray]:
+    line_iter = iter(lines)
+    energy_line = next(
+        (line for line in line_iter if 'FINAL HEAT OF FORMATION' in line), None
+    )
+    if energy_line is None:
+        raise ValueError('MOPAC output is missing FINAL HEAT OF FORMATION')
+    energy = _parse_mopac_energy(energy_line)
+    derivatives_line = next(
+        (
+            line
+            for line in line_iter
+            if 'FINAL' in line and 'POINT' in line and 'DERIVATIVES' in line
+        ),
+        None,
+    )
+    if derivatives_line is None:
+        raise ValueError('MOPAC output is missing FINAL POINT AND DERIVATIVES block')
+    n_components = 3 * n_gradient_rows
+    gradient_values = [
+        _read_mopac_gradient_value(line_iter, i + 1, n_components)
+        for i in range(n_components)
+    ]
+    gradients: FloatArray = np.array(gradient_values, dtype=float).reshape(
+        (n_gradient_rows, 3)
+    )
+    return energy, gradients
+
+
 def MopacSolver(
     cmd: str = 'mopac',
     method: str = 'PM7',
@@ -93,17 +167,8 @@ def MopacSolver(
                 f.write(mopac_input)
             subprocess.check_call([cmd, input_file])
             with open(os.path.join(tmpdir, 'job.out')) as f:
-                energy = float(
-                    next(l for l in f if 'FINAL HEAT OF FORMATION' in l).split()[5]
-                )
-                next(l for l in f if 'FINAL  POINT  AND  DERIVATIVES' in l)
-                next(f)
-                next(f)
-                gradients = np.array(
-                    [
-                        [float(next(f).split()[6]) for _ in range(3)]
-                        for _ in range(len(atoms) + (0 if lattice is None else 3))
-                    ]
+                energy, gradients = _parse_mopac_output(
+                    f, len(atoms) + (0 if lattice is None else 3)
                 )
             atoms, lattice = yield energy * kcal, gradients * kcal / angstrom
     finally:

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,8 +1,15 @@
+from io import StringIO
+
 import numpy as np
 import pytest
 
 from berny.coords import angstrom
-from berny.solvers import GenericSolver, _diff5, _mopac_keyword_line
+from berny.solvers import (
+    GenericSolver,
+    _diff5,
+    _mopac_keyword_line,
+    _parse_mopac_output,
+)
 
 
 def test_mopac_neutral_singlet():
@@ -24,6 +31,38 @@ def test_mopac_doublet_cation():
 def test_mopac_unsupported_multiplicity():
     with pytest.raises(ValueError, match='unsupported MOPAC multiplicity'):
         _mopac_keyword_line('PM7', 0, 99)
+
+
+def test_parse_mopac_output_accepts_derivative_table_variants():
+    output = """\
+FINAL HEAT OF FORMATION = -12.5 KCAL/MOL
+
+FINAL  POINT  AND  DERIVATIVES
+
+PARAMETER     ATOM    TYPE            VALUE        GRADIENT
+   1          1  C    CARTESIAN X    -0.000187      0.975569  KCAL/ANGSTROM
+   2          1  C    CARTESIAN Y   357.799425  KCAL/ANGSTROM
+   3          1  C    CARTESIAN Z   -48.096494  KCAL/ANGSTROM
+"""
+
+    energy, gradients = _parse_mopac_output(StringIO(output), 1)
+
+    assert energy == pytest.approx(-12.5)
+    np.testing.assert_allclose(gradients, [[0.975569, 357.799425, -48.096494]])
+
+
+def test_parse_mopac_output_reports_truncated_derivatives_block():
+    output = """\
+FINAL HEAT OF FORMATION = -12.5 KCAL/MOL
+
+FINAL  POINT  AND  DERIVATIVES
+
+PARAMETER     ATOM    TYPE            VALUE        GRADIENT
+   1          1  C    CARTESIAN X     0.975569  KCAL/ANGSTROM
+"""
+
+    with pytest.raises(ValueError, match='gradient component 2 of 3'):
+        _parse_mopac_output(StringIO(output), 1)
 
 
 def test_diff5_recovers_derivative_of_cubic():


### PR DESCRIPTION
## Summary
- parse MOPAC derivative rows by taking the numeric value before `KCAL/ANGSTROM` instead of assuming a fixed column index
- raise clear `ValueError`s when the final heat or derivative block is missing/truncated
- add parser-level tests for variant derivative row layouts and truncated output

This addresses the MOPAC parser failures described in #130; it does not try to handle the separate line-search or linear-coordinate cases from that issue.

## Tests
- `uv run --python 3.11 --with-editable '.[test]' pytest -q tests/test_solvers.py`
- `uv run --python 3.11 --with-editable '.[test]' pytest -q tests --ignore=tests/test_optimize.py`
- `uv run --python 3.11 --with ruff ruff check src/berny/solvers.py tests/test_solvers.py`
- `uv run --python 3.11 --with black black --check src/berny/solvers.py tests/test_solvers.py`
- `uv run --python 3.11 --with-editable . --with mypy python -m mypy src/berny/solvers.py`

Not run: `scripts/check.sh` because this local machine does not have the `mopac` executable required by `tests/test_optimize.py`.

AI assistance was used under my direction.
