### PR TITLE
Make MOPAC AUX parse and linear-bend dihedrals fail with clear diagnostics

### DIFF
--- a/src/berny/coords.py
+++ b/src/berny/coords.py
@@ -31,6 +31,10 @@ IntArray = NDArray[np.integer[Any]]
 EvalReturn = float | tuple[float, list[FloatArray]]
 
 
+class CoordinateError(Exception):
+    """Raised when internal-coordinate construction hits an unsupported case."""
+
+
 class InternalCoord:
     #: 0-based atom indices that define this coordinate. Set by each
     #: subclass's ``__init__``.
@@ -911,8 +915,15 @@ def get_dihedrals(
     linear_r = [
         n for n, ang in zip(neigh_r, angles_r) if ang >= pi - lin_thre or ang < lin_thre
     ]
-    assert len(linear_l) <= 1
-    assert len(linear_r) <= 1
+    if len(linear_l) > 1 or len(linear_r) > 1:
+        raise CoordinateError(
+            'Cannot build dihedrals through a near-linear chain with a '
+            'branching terminus: the linear-chain extension supports at most '
+            f'one near-linear neighbour per end (center={center}, '
+            f'linear_l={linear_l}, linear_r={linear_r}). This typically '
+            'arises in fully linear-rich systems such as long poly(phenylene-'
+            'ethynylene) chains.'
+        )
     dihedrals: list[Dihedral] = []
     if center[0] < center[-1]:
         nweak = len(

--- a/src/berny/solvers.py
+++ b/src/berny/solvers.py
@@ -71,12 +71,18 @@ def _parse_mopac_aux(path: str, n_grad: int) -> tuple[float, FloatArray]:
             if line.startswith(' HEAT_OF_FORMATION:KCAL/MOL='):
                 energy = float(line.split('=', 1)[1].replace('D', 'E'))
             elif line.startswith(' GRADIENTS:KCAL/MOL/ANGSTROM'):
-                values: list[float] = []
-                while len(values) < n_grad:
-                    values += [float(t.replace('D', 'E')) for t in next(lines).split()]
                 if energy is None:
                     raise ValueError('no HEAT_OF_FORMATION found in MOPAC AUX file')
-                return energy, np.array(values).reshape(-1, 3)
+                values: list[float] = []
+                for grad_line in lines:
+                    values += [float(t.replace('D', 'E')) for t in grad_line.split()]
+                    if len(values) >= n_grad:
+                        return energy, np.array(values[:n_grad]).reshape(-1, 3)
+                raise ValueError(
+                    'MOPAC AUX GRADIENTS block is truncated: expected '
+                    f'{n_grad} gradient components, found {len(values)} '
+                    '(MOPAC likely failed or was interrupted)'
+                )
     raise ValueError('no GRADIENTS found in MOPAC AUX file')
 
 

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -4,11 +4,13 @@ import pytest
 from berny.coords import (
     Angle,
     Bond,
+    CoordinateError,
     Dihedral,
     InternalCoords,
     _DummySpec,
     _perp_from_ref,
     angstrom,
+    get_dihedrals,
 )
 from berny.geomlib import Geometry
 from berny.species_data import get_property, species_data
@@ -381,6 +383,27 @@ def _methoxy_h_coords(hco_angle_deg):
 
 def _methoxy_h(hco_angle_deg):
     return Geometry(['H', 'C', 'H', 'H', 'O', 'H'], _methoxy_h_coords(hco_angle_deg))
+
+
+def test_get_dihedrals_branching_linear_terminus_raises_diagnostic():
+    # A center terminus with two near-linear neighbours breaks the assumption
+    # of the single-chain linear extension. The bare ``assert`` this used to
+    # hit surfaced as an opaque ``AssertionError`` (issue #130, PPE_n6); it now
+    # raises a contextual ``CoordinateError``.
+    coords = np.array(
+        [
+            [0.0, 0.0, 0.0],  # 0: center start
+            [1.0, 0.0, 0.0],  # 1: center end
+            [-1.0, 0.02, 0.0],  # 2: near-linear neighbour of 0
+            [-1.0, -0.02, 0.0],  # 3: near-linear neighbour of 0
+        ]
+    )
+    bondmatrix = np.zeros((4, 4), dtype=bool)
+    for i, j in [(0, 1), (0, 2), (0, 3)]:
+        bondmatrix[i, j] = bondmatrix[j, i] = True
+    C = bondmatrix.copy()
+    with pytest.raises(CoordinateError, match='branching terminus'):
+        get_dihedrals([0, 1], coords, bondmatrix, C)
 
 
 def test_near_linear_angle_dropped_on_non_sp_centre():

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -49,6 +49,20 @@ def test_parse_mopac_aux_missing_gradients(tmp_path):
         _parse_mopac_aux(str(aux), 9)
 
 
+def test_parse_mopac_aux_truncated_gradients(tmp_path):
+    # GRADIENTS block present but cut short (MOPAC died mid-write): must raise
+    # a clear, contextual error rather than letting ``next`` exhaust the file
+    # and surface an opaque ``StopIteration``/``RuntimeError`` (see issue #130).
+    aux = tmp_path / 'job.aux'
+    aux.write_text(
+        ' HEAT_OF_FORMATION:KCAL/MOL=-0.577822806548975D+02\n'
+        ' GRADIENTS:KCAL/MOL/ANGSTROM[09]=\n'
+        '  -3.4312143657544   0.0000000507512  -2.3676270992310\n'
+    )
+    with pytest.raises(ValueError, match='truncated'):
+        _parse_mopac_aux(str(aux), 9)
+
+
 def test_parse_mopac_aux_gradients_before_energy(tmp_path):
     # A GRADIENTS block with no preceding HEAT_OF_FORMATION is malformed.
     aux = tmp_path / 'job.aux'


### PR DESCRIPTION
Addresses the remaining opaque-failure cases from #130 (oligomer benchmark, analysed in #128).

## Context

Switching `MopacSolver` to the AUX parser (#136) already fixed four of the six failures: the two nylon-6 `KCAL/ANGSTROM` fixed-column errors and the two `StopIteration` cases that came from the old `.out` fixed-column parsing (that code is gone). Two opaque-failure modes survive, and this PR makes both surface a clear, contextual error — matching the issue's two most-actionable items.

## Changes

**`_parse_mopac_aux` — truncation tolerance (`solvers.py`)**
A `GRADIENTS` block that is present but cut short (MOPAC died or was interrupted mid-write) let the `next(lines)` loop run off the end of the file. The resulting `StopIteration` propagated through the `MopacSolver` generator frame, where PEP 479 re-raises it as an opaque `RuntimeError`. The remaining lines are now iterated explicitly and a contextual `ValueError` is raised reporting how many gradient components were found vs. expected. The energy-presence check also moved ahead of the gradient read.

**`get_dihedrals` — diagnostic instead of bare assert (`coords.py`)**
A near-linear chain terminus with more than one near-linear neighbour (fully linear-rich systems such as long PPE chains) tripped `assert len(linear_l) <= 1` / `assert len(linear_r) <= 1`, surfacing as a bare `AssertionError` (PPE_n6). It now raises a new `CoordinateError` carrying the `center` and the offending neighbour lists.

## Out of scope (per the issue, "separate")

- The deeper linear-bend coordinate handling for fully linear-rich PPE chains (the underlying cause behind PPE_n6/n7/n8).
- The line-search bracketing failure `Cannot find f(x) > 0` (`Math.py`) — already a clear message, not an opaque failure.

## Tests

- `test_parse_mopac_aux_truncated_gradients` — truncated AUX block → `ValueError(match='truncated')`.
- `test_get_dihedrals_branching_linear_terminus_raises_diagnostic` — synthetic two-near-linear-neighbour terminus → `CoordinateError(match='branching terminus')`.

Full suite (`scripts/check.sh`: ruff, black, mypy, pytest, sphinx) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011xjX1pTsjVdrMz7DxKr2MZ)_