### PR TITLE
plot_convergence: make --solver generic so xtb/pyscf trajectories plot

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -272,16 +272,20 @@ jobs:
               --solvers mopac pyscf xtb
           done
       - name: Plot energy convergence
-        # One combined figure per benchmark (mopac is the auto-trigger solver;
-        # plot_convergence.py skips a benchmark with no mopac shards). always()
-        # so a regression exit-1 from the Aggregate step still yields plots.
+        # One combined figure per (benchmark, solver) axis. plot_convergence.py
+        # skips an axis with no shards, so iterating every solver is safe across
+        # all trigger combinations (the auto-trigger produces mopac shards; a
+        # full dispatch adds pyscf / xtb). always() so a regression exit-1 from
+        # the Aggregate step still yields plots.
         if: always()
         run: |
           for bench in birkholz baker; do
-            python scripts/plot_convergence.py \
-              --benchmark "$bench" \
-              --solver mopac \
-              --results-dir all-results
+            for solver in mopac pyscf xtb; do
+              python scripts/plot_convergence.py \
+                --benchmark "$bench" \
+                --solver "$solver" \
+                --results-dir all-results
+            done
           done
       - name: Publish plots and embed in run summary
         # Inline images in a job summary need a public URL (GitHub strips

--- a/scripts/plot_convergence.py
+++ b/scripts/plot_convergence.py
@@ -7,16 +7,18 @@ downloads) and draws a single combined figure: one curve per molecule of the
 energy above the run's minimum, ``E_n - min(E)``, in kcal/mol on a log axis
 against the optimization step. The converged point itself (``E_n == min(E)``)
 is dropped since it has no place on a log axis. Saved to
-``results/convergence-<benchmark>.png``.
+``results/convergence-<benchmark>-<solver>.png``.
 
 Usage::
 
     scripts/plot_convergence.py --results-dir DIR [--benchmark NAME]
-                                [--solver mopac|pyscf] [--out PATH]
+                                [--solver SOLVER] [--out PATH]
 
-``--benchmark`` mirrors ``benchmark.py``; the CI auto-trigger runs mopac on
-both reference sets, so the workflow invokes this once per benchmark to get a
-side-by-side pair of plots.
+``--benchmark`` mirrors ``benchmark.py``; the CI auto-trigger runs every solver
+on both reference sets, so the workflow invokes this once per (benchmark,
+solver) axis to get a plot for each. ``--solver`` accepts any string -- the plot
+is drawn straight from the recorded energy trajectories, which have the same
+shape for every runner, so there is no per-solver logic to gate on.
 """
 
 import argparse
@@ -94,25 +96,39 @@ def main(argv=None):
     )
     ap.add_argument(
         '--solver',
-        choices=['mopac', 'pyscf'],
         default='mopac',
-        help='which solver the shards were run with (default: mopac)',
+        help=(
+            'which solver the shards were run with (default: mopac). Any '
+            'value is accepted: the plot is built straight from the recorded '
+            'energy trajectories, which have the same shape for every runner, '
+            'so no per-solver logic gates this script.'
+        ),
     )
     ap.add_argument(
         '--out',
         type=Path,
         default=None,
-        help='output PNG path (default: results/convergence-<benchmark>.png)',
+        help='output PNG path (default: results/convergence-<benchmark>-<solver>.png)',
     )
     args = ap.parse_args(argv)
     if args.out is None:
-        args.out = Path(f'results/convergence-{args.benchmark}.png')
+        # Include the solver so plotting multiple solvers for one benchmark
+        # writes a figure per axis rather than overwriting a shared file.
+        args.out = Path(f'results/convergence-{args.benchmark}-{args.solver}.png')
 
     trajectories = load_trajectories(args.results_dir, args.benchmark, args.solver)
-    # Mirror aggregate_benchmark.py: silently skip a benchmark/solver axis with
-    # no shard files so a multi-benchmark run that only exercised one set
-    # doesn't error or leave an empty figure behind.
+    # Mirror aggregate_benchmark.py: skip a benchmark/solver axis with no shard
+    # files so a multi-benchmark run that only exercised one set doesn't error or
+    # leave an empty figure behind. Now that --solver accepts any string, a
+    # typo'd name lands here too; note it on stderr so it isn't indistinguishable
+    # from a legitimately empty axis, but still exit 0 so a workflow loop over
+    # solvers stays unaffected by axes it didn't run.
     if not trajectories:
+        print(
+            f'no {args.solver}-{args.benchmark}-*.json shards in '
+            f'{args.results_dir}; nothing to plot',
+            file=sys.stderr,
+        )
         return 0
     plot(args.benchmark, args.solver, trajectories, args.out)
     print(f'wrote {args.out} ({len(trajectories)} molecules)')


### PR DESCRIPTION
## Why

When the xtb runner landed (#139), `benchmark.py` and `aggregate_benchmark.py` were extended for xtb, so the run summary now shows an xtb step-count table. But `scripts/plot_convergence.py` was not touched, so the summary has **no matching energy-convergence plot for xtb** — and, for the same reason, never for pyscf either.

The cause is purely a guard, not a real constraint. The plotter has no per-solver logic: it globs the `<solver>-<benchmark>-*.json` shards and draws `E − E_min` straight from the recorded `energies` arrays, which have the identical shape for every runner. Yet `--solver` was gated by `choices=['mopac', 'pyscf']`, and the workflow's plot step hard-coded `--solver mopac`. So the data was always there (every shard carries the full per-step energy trajectory) — it just never got rendered.

## What

- **Drop the `choices` guard** in `plot_convergence.py`; `--solver` accepts any string (default still `mopac`). No body changes needed — the plot was already solver-agnostic.
- **Note an empty axis on stderr** instead of returning silently, so a typo'd solver name is distinguishable from a legitimately empty axis. Still exits 0 so a workflow loop over solvers is unaffected by axes it didn't run.
- **Include the solver in the default output name** (`convergence-<benchmark>-<solver>.png`) so plotting several solvers for one benchmark writes a figure per axis rather than overwriting a shared file. The publish/upload steps already glob `convergence-*.png` and derive alt text from the filename, so they pick up the new names unchanged.
- **Loop the workflow's plot step over `mopac pyscf xtb`**; the script skips axes with no shards, so this is safe across all trigger combinations (auto-trigger produces mopac shards; a full dispatch adds pyscf / xtb).

## Verification

Ran the generic plotter against local xtb benchmark shards for both sets:

```
wrote results/convergence-baker-xtb.png (30 molecules)
wrote results/convergence-birkholz-xtb.png (19 molecules)
```

Default naming now embeds the solver, and a typo'd solver prints `no <solver>-<benchmark>-*.json shards … nothing to plot` and exits 0. `ruff check` and `black --check` pass on the modified script; mypy scopes to `src/berny` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HZCnvW6MmBsidGsdz9bSJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016HZCnvW6MmBsidGsdz9bSJ)_