### PR TITLE
benchmark: size xtb CI shards from measured cost; seed xtb_gfn2_steps

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -66,8 +66,13 @@ jobs:
         #     --exclude easc --nbins 3      # fast-mopac batches
         #   python scripts/plan_batches.py --solvers pyscf \
         #     --exclude azadirachtin --nbins 7
+        #   python scripts/plan_batches.py --benchmark birkholz --solvers xtb
+        #   python scripts/plan_batches.py --benchmark baker --solvers xtb --nbins 1
         # pyscf excludes azadirachtin: ~526s/call × 77 paper_steps ≈ 11 h,
-        # which busts GitHub's 360-min job cap. It still runs under mopac.
+        # which busts GitHub's 360-min job cap. It still runs under mopac and xtb
+        # (one GFN2-xTB call is sub-second, so azadirachtin costs ~45 s total).
+        # baker xtb is pinned to one shard (--nbins 1): ~3 s of total compute, so
+        # extra shards would be pure per-job setup overhead.
         run: |
           python - >> "$GITHUB_OUTPUT" <<'PY'
           import json, os
@@ -107,30 +112,43 @@ jobs:
               {"solver": "pyscf", "batch_id": "b3", "molecules": "histidine acanil01 trisilacyclohexane_135 hydroxybicyclopentane_2 neopentane acetone ammonia water"},
               {"solver": "pyscf", "batch_id": "b4", "molecules": "dimethylpentane pterin difuropyrazine difluoronaphthalene_15 achtar10 difluorobenzene_13 allene hydroxysulfane acetylene"},
           ]
-          # GFN2-xTB shards reuse the mopac molecule groupings (same per-call
-          # cost class) but run under the xtb solver. xtb is dispatch-only --
-          # it is not part of the push/pull_request auto-trigger pool.
-          xtb_fast = [{**s, "solver": "xtb"} for s in mopac_fast]
-          xtb_full = [{**s, "solver": "xtb"} for s in mopac_full]
-          baker_xtb = [{**s, "solver": "xtb"} for s in baker_mopac]
+          # GFN2-xTB shards are sized by scripts/plan_batches.py (per-call tblite
+          # cost × xtb_gfn2_steps), NOT cloned from mopac: xtb's cost profile is
+          # different (no pathological per-call outlier like easc under PM7), so
+          # the mopac groupings were badly unbalanced for it. Like pyscf, xtb has
+          # no fast/full distinction -- there is no easc-style molecule to
+          # quarantine -- so one birkholz pool serves both birkholz-* options.
+          # xtb is dispatch-only -- not in the push/pull_request auto-trigger pool.
+          birkholz_xtb = [
+              {"solver": "xtb", "batch_id": "b0", "molecules": "azadirachtin"},
+              {"solver": "xtb", "batch_id": "b1", "molecules": "artemisinin estradiol sphingomyelin"},
+              {"solver": "xtb", "batch_id": "b2", "molecules": "vitamin_c easc inosine_cation zn_edta bisphenol_a penicillin_v tamoxifen raffinose"},
+              {"solver": "xtb", "batch_id": "b3", "molecules": "mg_porphin diisobutyl_phthalate codeine ochratoxin_a avobenzone maltose cetirizine"},
+          ]
+          # Baker under xtb is ~3 s of total compute (small organics); like
+          # baker_mopac, one shard is plenty -- extra shards would be dominated
+          # by per-job setup overhead.
+          baker_xtb = [
+              {"solver": "xtb", "batch_id": "b0", "molecules": "water hydroxysulfane acetylene ammonia allene methylamine ethane disilyl_ether furan ethanol acetone difluorobenzene_13 trifluorobenzene_135 benzene hydroxybicyclopentane_2 benzaldehyde achtar10 difuropyrazine pterin mesityl_oxide neopentane trisilacyclohexane_135 difluoronaphthalene_15 naphthalene acanil01 histidine dimethylpentane caffeine benzidine menthone"},
+          ]
           # The "benchmark" key on each shard is consumed below to set the
           # --benchmark flag on benchmark.py and threads through to the
           # aggregate step's --benchmark / artifact-name suffix.
-          for s in mopac_fast + mopac_full + pyscf + xtb_fast + xtb_full:
+          for s in mopac_fast + mopac_full + pyscf + birkholz_xtb:
               s["benchmark"] = "birkholz"
           for s in baker_mopac + baker_pyscf + baker_xtb:
               s["benchmark"] = "baker"
           # (benchmark, solver) -> ordered list of shard pools to pull from.
-          # pyscf has no fast/full distinction; both birkholz-* benchmarks
-          # use the same `pyscf` pool when solver is pyscf or both.
+          # pyscf and xtb have no fast/full distinction; both birkholz-* options
+          # reuse the same single pool (`pyscf` / `birkholz_xtb`) for them.
           pools_by_axes = {
               ("birkholz-fast", "mopac"): [mopac_fast],
               ("birkholz-fast", "pyscf"): [pyscf],
-              ("birkholz-fast", "xtb"):   [xtb_fast],
+              ("birkholz-fast", "xtb"):   [birkholz_xtb],
               ("birkholz-fast", "both"):  [mopac_fast, pyscf],
               ("birkholz-full", "mopac"): [mopac_full],
               ("birkholz-full", "pyscf"): [pyscf],
-              ("birkholz-full", "xtb"):   [xtb_full],
+              ("birkholz-full", "xtb"):   [birkholz_xtb],
               ("birkholz-full", "both"):  [mopac_full, pyscf],
               ("baker",         "mopac"): [baker_mopac],
               ("baker",         "pyscf"): [baker_pyscf],

--- a/scripts/plan_batches.py
+++ b/scripts/plan_batches.py
@@ -1,21 +1,27 @@
 #!/usr/bin/env python3
-"""Offline tool: bin-pack the Birkholz-Schlegel benchmark into parallel batches.
+"""Offline tool: bin-pack a benchmark set into parallel batches.
+
+``--benchmark`` selects the set (``birkholz`` default, or ``baker``); both ship
+with the package under :mod:`berny.benchmarks`.
 
 For each solver, this script times one energy+gradient call per molecule
 (``mopac`` with ``1SCF GRADIENTS``; ``pyscf`` with one SCF + analytic
-gradient), multiplies by the pyberny step count from ``reference.json``,
-and prints a YAML fragment ready to paste into the
-``strategy.matrix.include`` block of ``.github/workflows/benchmark.yaml``.
+gradient; ``xtb`` with one GFN2-xTB singlepoint through tblite), multiplies by
+the pyberny step count from ``reference.json``, and prints a YAML fragment ready
+to paste into the ``strategy.matrix.include`` block of
+``.github/workflows/benchmark.yaml``.
 
 The per-call timing is the only cost source — there is no analytical
 N**p fallback. Per-iteration cost varies by an order of magnitude across
 this dataset (``easc`` with Al/Cl is ~35x slower than CHNO organics of
 similar size), and no closed-form expression in ``atoms`` captures it.
 
-``pyberny_steps`` is ``null`` for every entry in ``reference.json``, so
-``paper_steps`` is the only available step proxy for pyscf.
-``mopac_pm7_steps`` is ``null`` for one molecule (``bisphenol_a``); the
-median over the rest is used.
+Step counts come from each solver's column in ``reference.json``
+(``mopac_pm7_steps`` / ``pyberny_steps`` / ``xtb_gfn2_steps``). Where that is
+``null`` for a molecule (a documented non-converger, e.g. ``azadirachtin`` /
+``raffinose`` under mopac) the fallback in ``FALLBACK_STEPS_KEY`` is used --
+``paper_steps`` for pyscf and xtb -- and if that too is missing the median over
+the rest stands in, so a single gap never bottlenecks planning.
 
 Bin-packing: Longest-Processing-Time-first (LPT). ``--nbins`` defaults
 to ``ceil(total / max_single)`` so the heaviest molecule does not
@@ -45,18 +51,30 @@ import time
 from pathlib import Path
 
 # Allow running from a source checkout without an installed editable package;
-# must happen before any ``berny`` import below. ``_measure_mopac`` /
-# ``_measure_pyscf`` rely on the same path for their late imports.
+# must happen before any ``berny`` import below. The ``_measure_*`` helpers rely
+# on the same path for their late imports.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 
-from berny.benchmarks import data_dir as _bench_data_dir
+from berny.benchmarks import BENCHMARKS, data_dir as _bench_data_dir
 
+# Data directory for the benchmark being planned. Module-global because the
+# per-call ``_measure_*`` helpers read it at call time; ``main`` rebinds it from
+# ``--benchmark`` before any measurement runs. Defaults to birkholz so importing
+# this module (or running without ``--benchmark``) keeps the historical behaviour.
 DATA = _bench_data_dir('birkholz')
 
-STEPS_KEY = {'mopac': 'mopac_pm7_steps', 'pyscf': 'pyberny_steps'}
+STEPS_KEY = {
+    'mopac': 'mopac_pm7_steps',
+    'pyscf': 'pyberny_steps',
+    'xtb': 'xtb_gfn2_steps',
+}
 # Used only if STEPS_KEY value is null for a given molecule.
-FALLBACK_STEPS_KEY = {'mopac': 'mopac_pm7_steps', 'pyscf': 'paper_steps'}
-REPEATS = {'mopac': 3, 'pyscf': 1}
+FALLBACK_STEPS_KEY = {
+    'mopac': 'mopac_pm7_steps',
+    'pyscf': 'paper_steps',
+    'xtb': 'paper_steps',
+}
+REPEATS = {'mopac': 3, 'pyscf': 1, 'xtb': 3}
 
 
 def _pin_threads():
@@ -133,7 +151,22 @@ def _measure_pyscf(name, ref):
     return time.perf_counter() - t0
 
 
-MEASURE = {'mopac': _measure_mopac, 'pyscf': _measure_pyscf}
+def _measure_xtb(name, ref):
+    from berny import geomlib
+    from berny.solvers import XTBSolver
+
+    geom = geomlib.readfile(str(DATA / f'{name}.xyz'))
+    # Drive the public solver one step: priming with next() then a single send()
+    # is exactly one GFN2-xTB energy+gradient evaluation through tblite, the same
+    # quantum the optimizer pays per pyberny step.
+    solver = XTBSolver(charge=ref['charge'], mult=ref['mult'])
+    next(solver)
+    t0 = time.perf_counter()
+    solver.send((list(geom), geom.lattice))
+    return time.perf_counter() - t0
+
+
+MEASURE = {'mopac': _measure_mopac, 'pyscf': _measure_pyscf, 'xtb': _measure_xtb}
 
 
 def _step_count(ref, solver, fallback):
@@ -224,7 +257,18 @@ def emit(reference, solvers, nbins_arg, cache, cache_path=None, exclude=()):
 
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument('--reference', type=Path, default=DATA / 'reference.json')
+    ap.add_argument(
+        '--benchmark',
+        choices=sorted(BENCHMARKS),
+        default='birkholz',
+        help='which benchmark set to plan (default: birkholz)',
+    )
+    ap.add_argument(
+        '--reference',
+        type=Path,
+        default=None,
+        help='reference.json path (default: derived from --benchmark)',
+    )
     ap.add_argument('--solvers', nargs='+', default=['mopac', 'pyscf'])
     ap.add_argument(
         '--nbins',
@@ -247,6 +291,10 @@ def main(argv=None):
         '--solvers entry; rerun per solver if exclusions differ)',
     )
     args = ap.parse_args(argv)
+    global DATA
+    DATA = _bench_data_dir(args.benchmark)
+    if args.reference is None:
+        args.reference = DATA / 'reference.json'
     _pin_threads()
     if 'mopac' in args.solvers and not shutil.which('mopac'):
         raise SystemExit('mopac not on PATH')

--- a/src/berny/benchmarks/baker_shajan_2023/SOURCE.md
+++ b/src/berny/benchmarks/baker_shajan_2023/SOURCE.md
@@ -60,6 +60,21 @@ MOPAC PM7 totals 274 steps over 29 molecules; ``caffeine`` is left
 documented-non-converger convention used by ``bisphenol_a`` in the
 ``birkholz_schlegel`` set.
 
+``xtb_gfn2_steps`` records the GFN2-xTB step counts (evaluated through the
+``tblite`` library; see ``berny.solvers.XTBSolver``). All 30 molecules
+converge under xTB within the 130-step ceiling -- including ``caffeine``, which
+is a non-converger under PM7 -- so no entry is ``null``. Unlike three
+flat-minimum molecules in the ``birkholz_schlegel`` set, every Baker molecule's
+xTB step count is reproducible to 0-1 steps across repeated single-host runs. As
+with the other solvers, those counts are not guaranteed bitwise across different
+hosts, so the same 7%/2-step drift tolerance applies and the committed
+single-host baseline should be confirmed from the first CI ``workflow_dispatch``
+xTB run. One GFN2-xTB call on these small organics is
+a few milliseconds, so the whole Baker set is only ~3 s of compute under xTB;
+like ``mopac_pm7_steps`` it runs as a single CI shard (``scripts/plan_batches.py
+--benchmark baker --solvers xtb --nbins 1``) -- extra shards would be dominated
+by per-job setup overhead.
+
 Coordinate data is treated as factual and is redistributed under
 pyberny's MPL-2.0 license, with attribution to Shajan et al. via this
 file and via the citation embedded in the comment line of each ``.xyz``.

--- a/src/berny/benchmarks/baker_shajan_2023/reference.json
+++ b/src/berny/benchmarks/baker_shajan_2023/reference.json
@@ -8,7 +8,8 @@
     "paper_steps": 7,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 7
+    "pyberny_steps": 7,
+    "xtb_gfn2_steps": 6
   },
   "acetone": {
     "atoms": 10,
@@ -19,7 +20,8 @@
     "paper_steps": 5,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 5
+    "pyberny_steps": 5,
+    "xtb_gfn2_steps": 5
   },
   "acetylene": {
     "atoms": 4,
@@ -30,7 +32,8 @@
     "paper_steps": 5,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 5
+    "pyberny_steps": 5,
+    "xtb_gfn2_steps": 4
   },
   "achtar10": {
     "atoms": 16,
@@ -41,7 +44,8 @@
     "paper_steps": 10,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 11
+    "pyberny_steps": 11,
+    "xtb_gfn2_steps": 30
   },
   "allene": {
     "atoms": 7,
@@ -52,7 +56,8 @@
     "paper_steps": 5,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 4
+    "pyberny_steps": 4,
+    "xtb_gfn2_steps": 5
   },
   "ammonia": {
     "atoms": 4,
@@ -63,7 +68,8 @@
     "paper_steps": 4,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 4
+    "pyberny_steps": 4,
+    "xtb_gfn2_steps": 4
   },
   "benzaldehyde": {
     "atoms": 14,
@@ -74,7 +80,8 @@
     "paper_steps": 7,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 6
+    "pyberny_steps": 6,
+    "xtb_gfn2_steps": 5
   },
   "benzene": {
     "atoms": 12,
@@ -85,7 +92,8 @@
     "paper_steps": 3,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 3
+    "pyberny_steps": 3,
+    "xtb_gfn2_steps": 3
   },
   "benzidine": {
     "atoms": 26,
@@ -96,7 +104,8 @@
     "paper_steps": 7,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 8
+    "pyberny_steps": 8,
+    "xtb_gfn2_steps": 8
   },
   "caffeine": {
     "atoms": 24,
@@ -107,7 +116,8 @@
     "paper_steps": 10,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 10
+    "pyberny_steps": 10,
+    "xtb_gfn2_steps": 7
   },
   "difluorobenzene_13": {
     "atoms": 12,
@@ -118,7 +128,8 @@
     "paper_steps": 4,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 4
+    "pyberny_steps": 4,
+    "xtb_gfn2_steps": 4
   },
   "difluoronaphthalene_15": {
     "atoms": 18,
@@ -129,7 +140,8 @@
     "paper_steps": 5,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 5
+    "pyberny_steps": 5,
+    "xtb_gfn2_steps": 4
   },
   "difuropyrazine": {
     "atoms": 16,
@@ -140,7 +152,8 @@
     "paper_steps": 7,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 7
+    "pyberny_steps": 7,
+    "xtb_gfn2_steps": 7
   },
   "dimethylpentane": {
     "atoms": 23,
@@ -151,7 +164,8 @@
     "paper_steps": 6,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 12
+    "pyberny_steps": 12,
+    "xtb_gfn2_steps": 12
   },
   "disilyl_ether": {
     "atoms": 9,
@@ -162,7 +176,8 @@
     "paper_steps": 9,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 12
+    "pyberny_steps": 12,
+    "xtb_gfn2_steps": 16
   },
   "ethane": {
     "atoms": 8,
@@ -173,7 +188,8 @@
     "paper_steps": 4,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 4
+    "pyberny_steps": 4,
+    "xtb_gfn2_steps": 4
   },
   "ethanol": {
     "atoms": 9,
@@ -184,7 +200,8 @@
     "paper_steps": 5,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 5
+    "pyberny_steps": 5,
+    "xtb_gfn2_steps": 5
   },
   "furan": {
     "atoms": 9,
@@ -195,7 +212,8 @@
     "paper_steps": 5,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 5
+    "pyberny_steps": 5,
+    "xtb_gfn2_steps": 5
   },
   "histidine": {
     "atoms": 20,
@@ -206,7 +224,8 @@
     "paper_steps": 14,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 20
+    "pyberny_steps": 20,
+    "xtb_gfn2_steps": 19
   },
   "hydroxybicyclopentane_2": {
     "atoms": 14,
@@ -217,7 +236,8 @@
     "paper_steps": 9,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 9
+    "pyberny_steps": 9,
+    "xtb_gfn2_steps": 9
   },
   "hydroxysulfane": {
     "atoms": 4,
@@ -228,7 +248,8 @@
     "paper_steps": 6,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 6
+    "pyberny_steps": 6,
+    "xtb_gfn2_steps": 7
   },
   "menthone": {
     "atoms": 29,
@@ -239,7 +260,8 @@
     "paper_steps": 10,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 13
+    "pyberny_steps": 13,
+    "xtb_gfn2_steps": 13
   },
   "mesityl_oxide": {
     "atoms": 17,
@@ -250,7 +272,8 @@
     "paper_steps": 7,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 7
+    "pyberny_steps": 7,
+    "xtb_gfn2_steps": 6
   },
   "methylamine": {
     "atoms": 7,
@@ -261,7 +284,8 @@
     "paper_steps": 4,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 4
+    "pyberny_steps": 4,
+    "xtb_gfn2_steps": 5
   },
   "naphthalene": {
     "atoms": 18,
@@ -272,7 +296,8 @@
     "paper_steps": 5,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 5
+    "pyberny_steps": 5,
+    "xtb_gfn2_steps": 4
   },
   "neopentane": {
     "atoms": 17,
@@ -283,7 +308,8 @@
     "paper_steps": 4,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 4
+    "pyberny_steps": 4,
+    "xtb_gfn2_steps": 3
   },
   "pterin": {
     "atoms": 17,
@@ -294,7 +320,8 @@
     "paper_steps": 11,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 8
+    "pyberny_steps": 8,
+    "xtb_gfn2_steps": 7
   },
   "trifluorobenzene_135": {
     "atoms": 12,
@@ -305,7 +332,8 @@
     "paper_steps": 4,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 4
+    "pyberny_steps": 4,
+    "xtb_gfn2_steps": 4
   },
   "trisilacyclohexane_135": {
     "atoms": 18,
@@ -316,7 +344,8 @@
     "paper_steps": 4,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 7
+    "pyberny_steps": 7,
+    "xtb_gfn2_steps": 7
   },
   "water": {
     "atoms": 3,
@@ -327,6 +356,7 @@
     "paper_steps": 4,
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
-    "pyberny_steps": 4
+    "pyberny_steps": 4,
+    "xtb_gfn2_steps": 4
   }
 }

--- a/src/berny/benchmarks/birkholz_schlegel/SOURCE.md
+++ b/src/berny/benchmarks/birkholz_schlegel/SOURCE.md
@@ -24,9 +24,9 @@ benchmark.
 ``paper_steps`` (from Table 1, "Standard" column) for each molecule, along
 with the QM ``paper_steps_method`` and ``paper_steps_basis`` used for that
 row (HF/3-21G for all molecules except EASC and Vitamin C, which use
-B3LYP/6-31G(d,p)). The ``pyberny_steps`` and ``mopac_pm7_steps`` fields are
-populated by running ``scripts/benchmark.py`` and committing the measured
-counts as a regression baseline.
+B3LYP/6-31G(d,p)). The ``pyberny_steps``, ``mopac_pm7_steps`` and
+``xtb_gfn2_steps`` fields are populated by running ``scripts/benchmark.py`` and
+committing the measured counts as a regression baseline.
 
 ``mopac_pm7_steps`` is left ``null`` for ``azadirachtin`` and ``raffinose``:
 both have very flat minima where, once ``MopacSolver`` switched to the
@@ -52,6 +52,35 @@ using the method and basis in ``paper_steps_method``/``paper_steps_basis``
 ``null``: ``azadirachtin`` is excluded from PySCF runs because its ~526 s/call
 cost would exceed GitHub's 6-hour job cap; ``ochratoxin_a`` did not converge
 within the 100-step default ceiling.
+
+``xtb_gfn2_steps`` records the GFN2-xTB step counts (evaluated through the
+``tblite`` library; see ``berny.solvers.XTBSolver``). All 19 molecules *converge*
+under xTB within the benchmark's 130-step ceiling -- including ``azadirachtin``
+and ``raffinose``, documented non-convergers under PM7, and ``ochratoxin_a``,
+which does not converge under PySCF. A single GFN2-xTB energy+gradient call is
+sub-second even for the 95-atom ``azadirachtin`` (~0.75 s), so unlike PySCF
+nothing has to be excluded on cost grounds.
+
+Three molecules are nonetheless left ``null`` -- ``bisphenol_a``, ``maltose``
+and ``penicillin_v``. These have flat minima where xTB's step count is not
+reproducible: ``tblite``'s OpenMP reductions are not bitwise-deterministic, and
+near a flat minimum the resulting ~1e-9 Ha noise reroutes the trust-radius path,
+so repeated runs on a *single* host already scatter well past the 7%/2-step gate
+(``bisphenol_a`` ranged 63-85 over four runs; ``penicillin_v`` 52-64;
+``maltose`` 76-86). They are the xTB analogue of ``raffinose``/``azadirachtin``
+under PM7 and have no meaningful value to gate on. The other 16 molecules are
+reproducible to 0-1 steps across runs. Like PM7, even those stable counts are
+not guaranteed bitwise across *different* hosts, so the same 7%/2-step drift
+tolerance applies; the committed values are a single-host baseline and should be
+confirmed (and refreshed if needed) from the first CI ``workflow_dispatch`` xTB
+run.
+
+xTB needs no fast/full batch split (no easc-style per-call outlier to
+quarantine): ``scripts/plan_batches.py`` bins it into four cost-balanced shards
+(per-call ``tblite`` time × ``xtb_gfn2_steps``, falling back to ``paper_steps``
+for the three ``null`` rows) used for both ``birkholz-fast`` and
+``birkholz-full``. The ``null`` molecules still *run* in those shards; only the
+regression gate skips them.
 
 Coordinate data is treated as factual and is redistributed under pyberny's
 MPL-2.0 license, with attribution to Birkholz & Schlegel via this file and

--- a/src/berny/benchmarks/birkholz_schlegel/reference.json
+++ b/src/berny/benchmarks/birkholz_schlegel/reference.json
@@ -8,7 +8,8 @@
     "paper_steps": 24,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 23
+    "pyberny_steps": 23,
+    "xtb_gfn2_steps": 27
   },
   "avobenzone": {
     "atoms": 45,
@@ -19,7 +20,8 @@
     "paper_steps": 43,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 83
+    "pyberny_steps": 83,
+    "xtb_gfn2_steps": 48
   },
   "azadirachtin": {
     "atoms": 95,
@@ -30,7 +32,8 @@
     "paper_steps": 77,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": null
+    "pyberny_steps": null,
+    "xtb_gfn2_steps": 60
   },
   "bisphenol_a": {
     "atoms": 33,
@@ -41,7 +44,8 @@
     "paper_steps": 31,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 50
+    "pyberny_steps": 50,
+    "xtb_gfn2_steps": null
   },
   "cetirizine": {
     "atoms": 52,
@@ -52,7 +56,8 @@
     "paper_steps": 35,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 51
+    "pyberny_steps": 51,
+    "xtb_gfn2_steps": 51
   },
   "codeine": {
     "atoms": 43,
@@ -63,7 +68,8 @@
     "paper_steps": 18,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 25
+    "pyberny_steps": 25,
+    "xtb_gfn2_steps": 36
   },
   "diisobutyl_phthalate": {
     "atoms": 42,
@@ -74,7 +80,8 @@
     "paper_steps": 27,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 90
+    "pyberny_steps": 90,
+    "xtb_gfn2_steps": 34
   },
   "easc": {
     "atoms": 26,
@@ -85,7 +92,8 @@
     "paper_steps": 40,
     "paper_steps_basis": "6-31G(d,p)",
     "paper_steps_method": "B3LYP",
-    "pyberny_steps": 33
+    "pyberny_steps": 33,
+    "xtb_gfn2_steps": 38
   },
   "estradiol": {
     "atoms": 44,
@@ -96,7 +104,8 @@
     "paper_steps": 21,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 12
+    "pyberny_steps": 12,
+    "xtb_gfn2_steps": 27
   },
   "inosine_cation": {
     "atoms": 31,
@@ -107,7 +116,8 @@
     "paper_steps": 41,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 50
+    "pyberny_steps": 50,
+    "xtb_gfn2_steps": 58
   },
   "maltose": {
     "atoms": 45,
@@ -118,7 +128,8 @@
     "paper_steps": 35,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 36
+    "pyberny_steps": 36,
+    "xtb_gfn2_steps": null
   },
   "mg_porphin": {
     "atoms": 37,
@@ -129,7 +140,8 @@
     "paper_steps": 14,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 14
+    "pyberny_steps": 14,
+    "xtb_gfn2_steps": 16
   },
   "ochratoxin_a": {
     "atoms": 45,
@@ -140,7 +152,8 @@
     "paper_steps": 31,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 87
+    "pyberny_steps": 87,
+    "xtb_gfn2_steps": 56
   },
   "penicillin_v": {
     "atoms": 42,
@@ -151,7 +164,8 @@
     "paper_steps": 31,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 35
+    "pyberny_steps": 35,
+    "xtb_gfn2_steps": null
   },
   "raffinose": {
     "atoms": 66,
@@ -162,7 +176,8 @@
     "paper_steps": 53,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 50
+    "pyberny_steps": 50,
+    "xtb_gfn2_steps": 47
   },
   "sphingomyelin": {
     "atoms": 84,
@@ -173,7 +188,8 @@
     "paper_steps": 56,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 61
+    "pyberny_steps": 61,
+    "xtb_gfn2_steps": 83
   },
   "tamoxifen": {
     "atoms": 57,
@@ -184,7 +200,8 @@
     "paper_steps": 35,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 43
+    "pyberny_steps": 43,
+    "xtb_gfn2_steps": 45
   },
   "vitamin_c": {
     "atoms": 20,
@@ -195,7 +212,8 @@
     "paper_steps": 18,
     "paper_steps_basis": "6-31G(d,p)",
     "paper_steps_method": "B3LYP",
-    "pyberny_steps": 22
+    "pyberny_steps": 22,
+    "xtb_gfn2_steps": 30
   },
   "zn_edta": {
     "atoms": 33,
@@ -206,6 +224,7 @@
     "paper_steps": 29,
     "paper_steps_basis": "3-21G",
     "paper_steps_method": "HF",
-    "pyberny_steps": 52
+    "pyberny_steps": 52,
+    "xtb_gfn2_steps": 40
   }
 }


### PR DESCRIPTION
## Why

The GFN2-xTB benchmark shards were **cloned** from the mopac batch groupings (`xtb_fast = [{**s, "solver": "xtb"} for s in mopac_fast]`, etc.), on the assumption of a "same per-call cost class." They were never sized for xtb — `scripts/plan_batches.py` (the LPT bin-packer that produced the mopac/pyscf bins) had no xtb support at all.

xtb's cost profile differs from PM7 in **both** per-call time and step count, so the cloned bins were badly unbalanced:
- **birkholz-fast**: ~2.2× max/min wall imbalance, each bin dominated by one molecule.
- **birkholz-full**: isolated `easc` (a ~90 s PM7 outlier that is only ~7 ms under xtb) in its own CI job while a sibling bin ran all 18 others — a ~91× imbalance.

## What

**Size the shards properly from a measured cost model:**
- `plan_batches.py` learns xtb — a single GFN2-xTB energy+gradient call is timed via the public `XTBSolver` and weighted by `xtb_gfn2_steps` (with `paper_steps` fallback). The tool is also made **benchmark-agnostic** (`--benchmark`) so it can plan baker as well as birkholz.
- Regenerate the xtb pools from that model. Like pyscf, xtb has no `easc`-style outlier to quarantine, so **one birkholz pool** (4 cost-balanced shards) serves both `birkholz-fast` and `birkholz-full`. Baker under xtb is **~3 s of total compute**, so it's pinned to a **single shard** (`--nbins 1`) — extra shards would be pure per-job setup overhead.

**Seed `xtb_gfn2_steps` in both `reference.json`** so the planner has real weights and the regression gate activates for xtb. Step counts were measured over **four repeated single-host runs**:
- Three birkholz molecules (`bisphenol_a`, `penicillin_v`, `maltose`) have flat minima where tblite's non-deterministic OpenMP reductions scatter the count well past the 7%/2-step gate **even on one host** (e.g. `bisphenol_a` ranged 63–85). These are left `null` — the xtb analogue of the `raffinose`/`azadirachtin` non-convergers under PM7. They still **run** in the shards; only the gate skips them.
- The other 16 birkholz and all 30 baker molecules are reproducible to 0–1 steps.

`SOURCE.md` (both sets) documents provenance and the null rationale, and notes the committed values are a **single-host baseline** that should be confirmed/refreshed from the first CI `workflow_dispatch` xtb run.

## Verification

- **Shard coverage** (via the workflow's own matrix builder): birkholz xtb → 4 shards / 19 molecules (unique, == reference); baker xtb → 1 shard / 30 molecules.
- **Balance**: birkholz xtb 31% cost spread (the residual is `azadirachtin`, a 44 s singleton that can't be split) vs. 120%+ for the old cloned bins.
- **Gate self-check**: replaying an independent 5th run through `regression_reason` against the seeded references → zero failures on both sets.
- `ruff` + `black` clean on `plan_batches.py`; both `reference.json` remain canonical `json.dumps(sort_keys, indent=2)`; full test suite 216 passed.

> Note: xtb is dispatch-only (not in the push/PR auto-trigger pool), so the newly-activated xtb gate only fires on a manual `workflow_dispatch` xtb run — it does not gate ordinary CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HZCnvW6MmBsidGsdz9bSJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016HZCnvW6MmBsidGsdz9bSJ)_