### PR TITLE
Switch default runner to xtb and remove MOPAC

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,20 +5,6 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-MOPAC_VERSION=23.2.5
-MOPAC_DIR="$CLAUDE_PROJECT_DIR/.claude/mopac"
-
-if [ ! -x "$MOPAC_DIR/bin/mopac" ]; then
-  mkdir -p "$MOPAC_DIR"
-  cd "$MOPAC_DIR"
-  wget -q "https://github.com/openmopac/mopac/releases/download/v${MOPAC_VERSION}/mopac-${MOPAC_VERSION}-linux.tar.gz"
-  tar --strip-components=1 -xzf "mopac-${MOPAC_VERSION}-linux.tar.gz"
-  rm "mopac-${MOPAC_VERSION}-linux.tar.gz"
-fi
-
-echo "export PATH=\"$MOPAC_DIR/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
-echo "export LD_LIBRARY_PATH=\"$MOPAC_DIR/lib:\${LD_LIBRARY_PATH:-}\"" >> "$CLAUDE_ENV_FILE"
-
 cd "$CLAUDE_PROJECT_DIR"
 # [doc] is needed for the sphinx-build step in scripts/check.sh. The Sphinx
 # step relies on `node` for sphinxcontrib-katex's server-side prerender; the

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,19 +8,16 @@ on:
       benchmark:
         description: 'Which benchmark to run'
         type: choice
-        # Neither backend has a fast/full distinction: xtb has no per-call
-        # outlier to quarantine (one GFN2-xTB call is sub-second even for the
-        # 95-atom azadirachtin) and pyscf's shards are identical for both
-        # birkholz-* options. birkholz-fast and birkholz-full therefore map to
-        # the same pools and are kept only as familiar labels. push/pull_request
+        # No fast/full distinction: xtb has no per-call outlier to quarantine
+        # (one GFN2-xTB call is sub-second even for the 95-atom azadirachtin)
+        # and pyscf's shards are the same regardless. push/pull_request
         # auto-trigger unions the birkholz and baker xtb pools so both reference
         # sets get exercised cheaply on every push; baker pyscf is
         # workflow_dispatch only because a full sweep is ~2 h.
         options:
-          - birkholz-fast
-          - birkholz-full
+          - birkholz
           - baker
-        default: birkholz-fast
+        default: birkholz
       solver:
         description: 'Which solver(s) to use'
         type: choice
@@ -119,18 +116,13 @@ jobs:
           for s in baker_pyscf + baker_xtb:
               s["benchmark"] = "baker"
           # (benchmark, solver) -> ordered list of shard pools to pull from.
-          # Neither pyscf nor xtb has a fast/full distinction; both birkholz-*
-          # options reuse the same single pool (`birkholz_xtb` / `pyscf`).
           pools_by_axes = {
-              ("birkholz-fast", "xtb"):   [birkholz_xtb],
-              ("birkholz-fast", "pyscf"): [pyscf],
-              ("birkholz-fast", "both"):  [birkholz_xtb, pyscf],
-              ("birkholz-full", "xtb"):   [birkholz_xtb],
-              ("birkholz-full", "pyscf"): [pyscf],
-              ("birkholz-full", "both"):  [birkholz_xtb, pyscf],
-              ("baker",         "xtb"):   [baker_xtb],
-              ("baker",         "pyscf"): [baker_pyscf],
-              ("baker",         "both"):  [baker_xtb, baker_pyscf],
+              ("birkholz", "xtb"):   [birkholz_xtb],
+              ("birkholz", "pyscf"): [pyscf],
+              ("birkholz", "both"):  [birkholz_xtb, pyscf],
+              ("baker",    "xtb"):   [baker_xtb],
+              ("baker",    "pyscf"): [baker_pyscf],
+              ("baker",    "both"):  [baker_xtb, baker_pyscf],
           }
           benchmark = os.environ["BENCHMARK"]
           solver = os.environ["SOLVER"]

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -8,13 +8,14 @@ on:
       benchmark:
         description: 'Which benchmark to run'
         type: choice
-        # birkholz-fast drops easc (~90 s on its own under mopac) and rebatches
-        # the remaining 18 mopac molecules into 3 bins of ~25 s each. pyscf
-        # has no fast/full distinction -- its shards are identical for both
-        # birkholz-fast and birkholz-full. push/pull_request auto-trigger
-        # unions ``mopac_fast`` (birkholz) with ``baker_mopac`` so both
-        # reference sets get exercised cheaply on every push; baker pyscf
-        # is workflow_dispatch only because a full sweep is ~2 h.
+        # Neither backend has a fast/full distinction: xtb has no per-call
+        # outlier to quarantine (one GFN2-xTB call is sub-second even for the
+        # 95-atom azadirachtin) and pyscf's shards are identical for both
+        # birkholz-* options. birkholz-fast and birkholz-full therefore map to
+        # the same pools and are kept only as familiar labels. push/pull_request
+        # auto-trigger unions the birkholz and baker xtb pools so both reference
+        # sets get exercised cheaply on every push; baker pyscf is
+        # workflow_dispatch only because a full sweep is ~2 h.
         options:
           - birkholz-fast
           - birkholz-full
@@ -24,11 +25,10 @@ on:
         description: 'Which solver(s) to use'
         type: choice
         options:
-          - mopac
-          - pyscf
           - xtb
+          - pyscf
           - both
-        default: mopac
+        default: xtb
       molecules:
         description: 'Subset of molecule names (space-separated; empty = all)'
         type: string
@@ -36,7 +36,7 @@ on:
 
 jobs:
   # Build the benchmark matrix dynamically so off-axis shards (e.g. all
-  # pyscf shards when `inputs.solver == 'mopac'`) and shards with no
+  # pyscf shards when `inputs.solver == 'xtb'`) and shards with no
   # molecule overlap with `inputs.molecules` are not instantiated at all.
   # A static matrix with per-step `if:` gates would still produce green
   # check-mark jobs for the skipped shards, which is misleading.
@@ -51,7 +51,7 @@ jobs:
         env:
           # `inputs.*` are empty on push / pull_request; the matrix builder
           # below uses EVENT to detect this case and unions every benchmark's
-          # cheap mopac pool. workflow_dispatch always sets BENCHMARK / SOLVER
+          # cheap xtb pool. workflow_dispatch always sets BENCHMARK / SOLVER
           # explicitly via the dropdowns.
           EVENT: ${{ github.event_name }}
           BENCHMARK: ${{ inputs.benchmark || '' }}
@@ -61,30 +61,18 @@ jobs:
         # Cost = measured single energy+gradient call × pyberny step count.
         # Rerun (per solver, since --nbins and --exclude differ) and paste a
         # fresh block if reference.json changes:
-        #   python scripts/plan_batches.py --solvers mopac
-        #   python scripts/plan_batches.py --solvers mopac \
-        #     --exclude easc --nbins 3      # fast-mopac batches
-        #   python scripts/plan_batches.py --solvers pyscf \
-        #     --exclude azadirachtin --nbins 7
         #   python scripts/plan_batches.py --benchmark birkholz --solvers xtb
         #   python scripts/plan_batches.py --benchmark baker --solvers xtb --nbins 1
+        #   python scripts/plan_batches.py --solvers pyscf \
+        #     --exclude azadirachtin --nbins 7
         # pyscf excludes azadirachtin: ~526s/call × 77 paper_steps ≈ 11 h,
-        # which busts GitHub's 360-min job cap. It still runs under mopac and xtb
-        # (one GFN2-xTB call is sub-second, so azadirachtin costs ~45 s total).
+        # which busts GitHub's 360-min job cap. It still runs under xtb (one
+        # GFN2-xTB call is sub-second, so azadirachtin costs ~45 s total).
         # baker xtb is pinned to one shard (--nbins 1): ~3 s of total compute, so
         # extra shards would be pure per-job setup overhead.
         run: |
           python - >> "$GITHUB_OUTPUT" <<'PY'
           import json, os
-          mopac_fast = [
-              {"solver": "mopac", "batch_id": "b0", "molecules": "inosine_cation mg_porphin penicillin_v artemisinin ochratoxin_a sphingomyelin"},
-              {"solver": "mopac", "batch_id": "b1", "molecules": "bisphenol_a diisobutyl_phthalate estradiol cetirizine tamoxifen azadirachtin"},
-              {"solver": "mopac", "batch_id": "b2", "molecules": "vitamin_c zn_edta codeine avobenzone maltose raffinose"},
-          ]
-          mopac_full = [
-              {"solver": "mopac", "batch_id": "b0", "molecules": "easc"},
-              {"solver": "mopac", "batch_id": "b1", "molecules": "vitamin_c inosine_cation zn_edta bisphenol_a mg_porphin penicillin_v diisobutyl_phthalate artemisinin codeine estradiol avobenzone ochratoxin_a maltose cetirizine tamoxifen raffinose sphingomyelin azadirachtin"},
-          ]
           pyscf = [
               {"solver": "pyscf", "batch_id": "b0", "molecules": "easc"},
               {"solver": "pyscf", "batch_id": "b1", "molecules": "raffinose"},
@@ -94,17 +82,11 @@ jobs:
               {"solver": "pyscf", "batch_id": "b5", "molecules": "penicillin_v diisobutyl_phthalate estradiol avobenzone"},
               {"solver": "pyscf", "batch_id": "b6", "molecules": "artemisinin codeine ochratoxin_a maltose"},
           ]
-          # All 30 Baker molecules are small organics. Mopac under PM7
-          # finishes the whole set in ~15s on a CI runner, so one shard is
-          # plenty -- additional shards would be dominated by per-job
-          # setup overhead (~60s of checkout + python + MOPAC install).
+          # All 30 Baker molecules are small organics.
           # Pyscf shards are LPT-balanced on the wall times measured by the
           # first manual-dispatch baseline run (PR #84); 5 bins lands every
           # shard at ~27 min, which is basically caffeine's own wall time
           # (26.5 min) -- adding more bins only grows per-job overhead.
-          baker_mopac = [
-              {"solver": "mopac", "batch_id": "b0", "molecules": "acanil01 acetone acetylene achtar10 allene ammonia benzaldehyde benzene benzidine caffeine difluorobenzene_13 difluoronaphthalene_15 difuropyrazine dimethylpentane disilyl_ether ethane ethanol furan histidine hydroxybicyclopentane_2 hydroxysulfane menthone mesityl_oxide methylamine naphthalene neopentane pterin trifluorobenzene_135 trisilacyclohexane_135 water"},
-          ]
           baker_pyscf = [
               {"solver": "pyscf", "batch_id": "b0", "molecules": "caffeine benzene furan"},
               {"solver": "pyscf", "batch_id": "b1", "molecules": "menthone mesityl_oxide trifluorobenzene_135 ethanol methylamine"},
@@ -113,57 +95,52 @@ jobs:
               {"solver": "pyscf", "batch_id": "b4", "molecules": "dimethylpentane pterin difuropyrazine difluoronaphthalene_15 achtar10 difluorobenzene_13 allene hydroxysulfane acetylene"},
           ]
           # GFN2-xTB shards are sized by scripts/plan_batches.py (per-call tblite
-          # cost × xtb_gfn2_steps), NOT cloned from mopac: xtb's cost profile is
-          # different (no pathological per-call outlier like easc under PM7), so
-          # the mopac groupings were badly unbalanced for it. Like pyscf, xtb has
-          # no fast/full distinction -- there is no easc-style molecule to
-          # quarantine -- so one birkholz pool serves both birkholz-* options.
-          # xtb is dispatch-only -- not in the push/pull_request auto-trigger pool.
+          # cost × xtb_gfn2_steps). xtb has no per-call outlier to quarantine, so
+          # like pyscf it has no fast/full distinction -- one birkholz pool serves
+          # both birkholz-* options. xtb is the default backend and the cheap
+          # pool the push/pull_request auto-trigger runs.
           birkholz_xtb = [
               {"solver": "xtb", "batch_id": "b0", "molecules": "azadirachtin"},
               {"solver": "xtb", "batch_id": "b1", "molecules": "artemisinin estradiol sphingomyelin"},
               {"solver": "xtb", "batch_id": "b2", "molecules": "vitamin_c easc inosine_cation zn_edta bisphenol_a penicillin_v tamoxifen raffinose"},
               {"solver": "xtb", "batch_id": "b3", "molecules": "mg_porphin diisobutyl_phthalate codeine ochratoxin_a avobenzone maltose cetirizine"},
           ]
-          # Baker under xtb is ~3 s of total compute (small organics); like
-          # baker_mopac, one shard is plenty -- extra shards would be dominated
-          # by per-job setup overhead.
+          # Baker under xtb is ~3 s of total compute (small organics); one shard
+          # is plenty -- extra shards would be dominated by per-job setup
+          # overhead.
           baker_xtb = [
               {"solver": "xtb", "batch_id": "b0", "molecules": "water hydroxysulfane acetylene ammonia allene methylamine ethane disilyl_ether furan ethanol acetone difluorobenzene_13 trifluorobenzene_135 benzene hydroxybicyclopentane_2 benzaldehyde achtar10 difuropyrazine pterin mesityl_oxide neopentane trisilacyclohexane_135 difluoronaphthalene_15 naphthalene acanil01 histidine dimethylpentane caffeine benzidine menthone"},
           ]
           # The "benchmark" key on each shard is consumed below to set the
           # --benchmark flag on benchmark.py and threads through to the
           # aggregate step's --benchmark / artifact-name suffix.
-          for s in mopac_fast + mopac_full + pyscf + birkholz_xtb:
+          for s in pyscf + birkholz_xtb:
               s["benchmark"] = "birkholz"
-          for s in baker_mopac + baker_pyscf + baker_xtb:
+          for s in baker_pyscf + baker_xtb:
               s["benchmark"] = "baker"
           # (benchmark, solver) -> ordered list of shard pools to pull from.
-          # pyscf and xtb have no fast/full distinction; both birkholz-* options
-          # reuse the same single pool (`pyscf` / `birkholz_xtb`) for them.
+          # Neither pyscf nor xtb has a fast/full distinction; both birkholz-*
+          # options reuse the same single pool (`birkholz_xtb` / `pyscf`).
           pools_by_axes = {
-              ("birkholz-fast", "mopac"): [mopac_fast],
-              ("birkholz-fast", "pyscf"): [pyscf],
               ("birkholz-fast", "xtb"):   [birkholz_xtb],
-              ("birkholz-fast", "both"):  [mopac_fast, pyscf],
-              ("birkholz-full", "mopac"): [mopac_full],
-              ("birkholz-full", "pyscf"): [pyscf],
+              ("birkholz-fast", "pyscf"): [pyscf],
+              ("birkholz-fast", "both"):  [birkholz_xtb, pyscf],
               ("birkholz-full", "xtb"):   [birkholz_xtb],
-              ("birkholz-full", "both"):  [mopac_full, pyscf],
-              ("baker",         "mopac"): [baker_mopac],
-              ("baker",         "pyscf"): [baker_pyscf],
+              ("birkholz-full", "pyscf"): [pyscf],
+              ("birkholz-full", "both"):  [birkholz_xtb, pyscf],
               ("baker",         "xtb"):   [baker_xtb],
-              ("baker",         "both"):  [baker_mopac, baker_pyscf],
+              ("baker",         "pyscf"): [baker_pyscf],
+              ("baker",         "both"):  [baker_xtb, baker_pyscf],
           }
           benchmark = os.environ["BENCHMARK"]
           solver = os.environ["SOLVER"]
           subset = os.environ["SUBSET"].split()
           if os.environ["EVENT"] != "workflow_dispatch":
-              # Auto-trigger on push / pull_request: run the cheap mopac pool
+              # Auto-trigger on push / pull_request: run the cheap xtb pool
               # from every benchmark so the auto-trigger covers both the
               # birkholz and baker reference sets. Workflow-dispatch users
               # still pick exactly one (benchmark, solver) combination.
-              shards = mopac_fast + baker_mopac
+              shards = birkholz_xtb + baker_xtb
           else:
               shards = [s for pool in pools_by_axes[(benchmark, solver)] for s in pool]
           include = []
@@ -200,26 +177,9 @@ jobs:
           echo "OMP_NUM_THREADS=$n" >> "$GITHUB_ENV"
           echo "MKL_NUM_THREADS=$n" >> "$GITHUB_ENV"
           echo "OPENBLAS_NUM_THREADS=$n" >> "$GITHUB_ENV"
-      - name: Install MOPAC
-        if: matrix.solver == 'mopac'
-        run: |
-          mkdir mopac
-          cd mopac
-          wget -q https://github.com/openmopac/mopac/releases/download/v${MOPAC_VERSION}/mopac-${MOPAC_VERSION}-linux.tar.gz
-          tar --strip-components=1 -xzf mopac-${MOPAC_VERSION}-linux.tar.gz
-          echo "$PWD/bin" >>$GITHUB_PATH
-          echo "LD_LIBRARY_PATH=$PWD/lib" >>$GITHUB_ENV
-        env:
-          MOPAC_VERSION: 23.2.5
       - name: Install pyberny
-        run: |
-          # mopac needs no Python backend; pyscf and xtb shards both come from
-          # the benchmark extra (pyscf + tblite).
-          if [ "${{ matrix.solver }}" = "mopac" ]; then
-            pip install -e .
-          else
-            pip install -e '.[benchmark]'
-          fi
+        # Both pyscf and xtb shards come from the benchmark extra (pyscf + tblite).
+        run: pip install -e '.[benchmark]'
       - name: Run batch
         env:
           BENCHMARK: ${{ matrix.benchmark }}
@@ -231,7 +191,7 @@ jobs:
           read -ra mols <<< "$MOLS"
           # Benchmark embedded in filename so a multi-benchmark run (the
           # push/pull_request auto-trigger covers both birkholz and baker)
-          # doesn't have birkholz/mopac-b0.json collide with baker/mopac-b0.json
+          # doesn't have birkholz/xtb-b0.json collide with baker/xtb-b0.json
           # when artifacts are merged in the aggregate step.
           python scripts/benchmark.py --benchmark "$BENCHMARK" \
             --solver "$SOLVER" \
@@ -287,18 +247,18 @@ jobs:
             python scripts/aggregate_benchmark.py \
               --benchmark "$bench" \
               --results-dir all-results \
-              --solvers mopac pyscf xtb
+              --solvers pyscf xtb
           done
       - name: Plot energy convergence
         # One combined figure per (benchmark, solver) axis. plot_convergence.py
         # skips an axis with no shards, so iterating every solver is safe across
-        # all trigger combinations (the auto-trigger produces mopac shards; a
-        # full dispatch adds pyscf / xtb). always() so a regression exit-1 from
+        # all trigger combinations (the auto-trigger produces xtb shards; a
+        # full dispatch adds pyscf). always() so a regression exit-1 from
         # the Aggregate step still yields plots.
         if: always()
         run: |
           for bench in birkholz baker; do
-            for solver in mopac pyscf xtb; do
+            for solver in pyscf xtb; do
               python scripts/plot_convergence.py \
                 --benchmark "$bench" \
                 --solver "$solver" \

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,22 +31,6 @@ jobs:
         with:
           node-version: "20"
 
-      # MOPAC is required by tests/test_optimize.py, which shells out to the
-      # `mopac` binary. Install it OUTSIDE the repository checkout (under
-      # $RUNNER_TEMP) so the extracted files are never picked up by `git add`
-      # in the agent's working tree.
-      - name: Install MOPAC
-        env:
-          MOPAC_VERSION: 23.2.5
-        run: |
-          mkdir -p "$RUNNER_TEMP/mopac"
-          cd "$RUNNER_TEMP/mopac"
-          wget -q https://github.com/openmopac/mopac/releases/download/v${MOPAC_VERSION}/mopac-${MOPAC_VERSION}-linux.tar.gz
-          tar --strip-components=1 -xzf mopac-${MOPAC_VERSION}-linux.tar.gz
-          rm mopac-${MOPAC_VERSION}-linux.tar.gz
-          echo "$PWD/bin" >>$GITHUB_PATH
-          echo "LD_LIBRARY_PATH=$PWD/lib" >>$GITHUB_ENV
-
       # The benchmark extra pulls in tblite (the GFN-xTB backend for
       # berny.solvers.XTBSolver) and pyscf, so both are importable in agent
       # sessions.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,16 +18,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install MOPAC
-        run: |
-          mkdir mopac
-          cd mopac
-          wget -q https://github.com/openmopac/mopac/releases/download/v${MOPAC_VERSION}/mopac-${MOPAC_VERSION}-linux.tar.gz
-          tar --strip-components=1 -xzf mopac-${MOPAC_VERSION}-linux.tar.gz
-          echo "$PWD/bin" >>$GITHUB_PATH
-          echo "LD_LIBRARY_PATH=$PWD/lib" >>$GITHUB_ENV
-        env:
-          MOPAC_VERSION: 23.2.5
       # tblite (the GFN-xTB backend behind berny.solvers.XTBSolver) lives in the
       # benchmark extra alongside pyscf; both ship wheels for every supported
       # Python, so the live XTBSolver tests run across the whole matrix.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,4 @@
 /doc/_check/
 /htmlcov/
 /poetry.lock
-.claude/mopac/
-/mopac/
 /fort*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `berny.solvers.MopacSolver`, the MOPAC backend. Use `berny.solvers.XTBSolver` (GFN2-xTB via the `tblite` library), now the default energy/gradient backend throughout the docs and benchmarks, instead.
+- The `"mopac"` geometry output format (`Geometry.dump(f, 'mopac')` / `Geometry.write('*.mopac')`).
 - The module-level `berny.berny.defaults` dict. Use `berny.BernyParams` (or pass overrides as keyword arguments to `Berny()`) instead.
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ do not leave them unchecked at end of turn.
 Do not chase inconsequential, non-deterministic CI slips. A sub-percent
 `codecov/project` dip from a single flaky line flipping hit/miss — especially
 when the diff adds no measured `berny` source and `codecov/patch` is clean — is
-noise, not a regression. Likewise, MOPAC PM7 benchmark step counts are not
+noise, not a regression. Likewise, GFN2-xTB benchmark step counts are not
 bitwise-reproducible across runners (see
-`src/berny/benchmarks/birkholz_schlegel/SOURCE.md`), so an occasional `birkholz mopac`
+`src/berny/benchmarks/birkholz_schlegel/SOURCE.md`), so an occasional `birkholz xtb`
 batch drifting past tolerance is flaky. Report these and move on; do not add
 coverage-gate config, loosen tolerances, or rewrite reference values to make
 them green.

--- a/README.md
+++ b/README.md
@@ -31,17 +31,18 @@ pip install -U pyberny
 ## Example
 
 The snippet below optimizes a geometry from `geom.xyz` end-to-end using
-[MOPAC](http://openmopac.net) as the energy/gradient backend:
+GFN2-xTB (via [tblite](https://tblite.readthedocs.io)) as the
+energy/gradient backend:
 
 ```python
 from berny import Berny, geomlib, optimize
-from berny.solvers import MopacSolver
+from berny.solvers import XTBSolver
 
 optimizer = Berny(geomlib.readfile('geom.xyz'))
-relaxed = optimize(optimizer, MopacSolver())
+relaxed = optimize(optimizer, XTBSolver())
 ```
 
-To plug in a different backend, replace `MopacSolver()` with any
+To plug in a different backend, replace `XTBSolver()` with any
 coroutine that follows the same interface (see the
 [documentation](https://jhrmnn.github.io/pyberny/master/getting-started.html)
 for the manual generator pattern and the solver protocol).

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -40,6 +40,4 @@ expected by :func:`~berny.optimize`.
 
 .. module:: berny.solvers
 
-.. autofunction:: MopacSolver
-
 .. autofunction:: XTBSolver

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -13,10 +13,10 @@ The Python API consists of coroutine :class:`~berny.Berny` and function
 :func:`~berny.optimize`::
 
    from berny import Berny, geomlib
-   from berny.solvers import MopacSolver
+   from berny.solvers import XTBSolver
 
    optimizer = Berny(geomlib.readfile('start.xyz'))
-   solver = MopacSolver()
+   solver = XTBSolver()
    next(solver)
    for geom in optimizer:
        energy, gradients = solver.send((list(geom), geom.lattice))
@@ -26,20 +26,14 @@ The Python API consists of coroutine :class:`~berny.Berny` and function
 or equivalently::
 
    from berny import Berny, geomlib, optimize
-   from berny.solvers import MopacSolver
-
-   relaxed = optimize(Berny(geomlib.readfile('start.xyz')), MopacSolver())
-
-For a smoother semiempirical surface than PM7,
-:func:`~berny.solvers.XTBSolver` evaluates the GFN-xTB methods through the
-`tblite <https://tblite.readthedocs.io>`_ library and can be dropped in
-wherever ``MopacSolver()`` appears::
-
    from berny.solvers import XTBSolver
 
    relaxed = optimize(Berny(geomlib.readfile('start.xyz')), XTBSolver())
 
-The backend is ``tblite``, shipped in the ``benchmark`` extra
+:func:`~berny.solvers.XTBSolver` evaluates the GFN-xTB methods (GFN2-xTB by
+default) through the `tblite <https://tblite.readthedocs.io>`_ library, which
+gives a smooth semiempirical potential-energy surface that is well behaved even
+near flat minima. The backend is ``tblite``, shipped in the ``benchmark`` extra
 (``pip install pyberny[benchmark]``); it can also be installed on its own with
 ``pip install tblite``.
 
@@ -56,9 +50,8 @@ gradient scanner)::
 The 19-molecule benchmark shipped with the package — the Birkholz–Schlegel
 2016 set [BirkholzTCA16]_ — is exposed under :mod:`berny.benchmarks` (key
 ``'birkholz'``; on-disk subdirectory ``berny/benchmarks/birkholz_schlegel/``).
-``scripts/benchmark.py`` runs the suite through that PySCF bridge (and
-optionally :func:`~berny.solvers.MopacSolver`) and prints a step-count
-comparison table.
+``scripts/benchmark.py`` runs the suite through :func:`~berny.solvers.XTBSolver`
+(the default) or that PySCF bridge and prints a step-count comparison table.
 
 A second 30-molecule set is exposed under :mod:`berny.benchmarks` as key
 ``'baker'`` (on-disk subdirectory ``berny/benchmarks/baker_shajan_2023/``);

--- a/scripts/aggregate_benchmark.py
+++ b/scripts/aggregate_benchmark.py
@@ -15,7 +15,7 @@ solver either failed to converge or drifts from its reference step count
 by more than 7% (with an absolute floor of 2 steps) — same rule as
 ``benchmark.py``'s exit-code logic. Entries with ``null`` reference step
 counts are skipped from the gate (documented non-convergers / unmeasured),
-so seeding ``pyberny_steps`` / ``mopac_pm7_steps`` in ``reference.json``
+so seeding ``pyberny_steps`` / ``xtb_gfn2_steps`` in ``reference.json``
 is what activates the regression check.
 """
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -123,11 +123,7 @@ def run_xtb(name, ref, data_dir, trace=None):
     from berny.solvers import XTBSolver
 
     geom = geomlib.readfile(str(data_dir / f'{name}.xyz'))
-    # Raise the ceiling above pyberny's default 100 steps so slow convergers
-    # are still reported rather than counted as failures. zn_edta, for
-    # instance, needs ~119 steps to converge once the generalised linear-bend
-    # trigger (PR #104) rebuilds around the Zn centre several times.
-    berny = Berny(geom, maxsteps=130, trace=trace)
+    berny = Berny(geom, trace=trace)
     solver = XTBSolver(charge=ref['charge'], mult=ref['mult'])
     energies = _optimize_recording_energies(berny, solver)
     return berny.converged, berny._n, energies

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -3,18 +3,19 @@
 
 Usage::
 
-    scripts/benchmark.py --solver pyscf [--benchmark NAME]
+    scripts/benchmark.py [--solver xtb] [--benchmark NAME]
                          [--molecules NAME ...] [--out PATH]
-    scripts/benchmark.py --solver mopac
+    scripts/benchmark.py --solver pyscf
 
 ``--benchmark`` selects which molecule set to run -- either ``birkholz``
 (the Birkholz-Schlegel 2016 19-molecule set, the default) or ``baker``
 (the 30-molecule Baker set from Shajan et al., chemrxiv 2023). Both sets
 ship with the package under :mod:`berny.benchmarks`.
-PySCF mode drives the optimization through ``pyscf.geomopt.berny_solver``
-and requires ``pip install pyberny[benchmark]``; MOPAC mode uses
-:func:`berny.solvers.MopacSolver` (charge and multiplicity from
-``reference.json``) and requires a ``mopac`` binary on ``$PATH``.
+xTB mode (the default) uses :func:`berny.solvers.XTBSolver` (GFN2-xTB,
+charge and multiplicity from ``reference.json``) and requires the
+``tblite`` package (``pip install pyberny[benchmark]``); PySCF mode drives
+the optimization through ``pyscf.geomopt.berny_solver`` and requires the
+same extra.
 A molecule fails the run when it either does not converge or its step
 count drifts from the reference by more than 7% (with an absolute floor
 of 2 steps, so the gate stays meaningful for small references);
@@ -60,7 +61,6 @@ del _n, _v
 import argparse  # noqa: E402
 import importlib.util  # noqa: E402
 import json  # noqa: E402
-import shutil  # noqa: E402
 import sys  # noqa: E402
 import time  # noqa: E402
 from pathlib import Path  # noqa: E402
@@ -119,30 +119,14 @@ def _optimize_recording_energies(berny, solver):
     return energies
 
 
-def run_mopac(name, ref, data_dir, trace=None):
-    from berny.solvers import MopacSolver
-
-    geom = geomlib.readfile(str(data_dir / f'{name}.xyz'))
-    # A couple of molecules (raffinose, sphingomyelin) need more than
-    # pyberny's default 100-step ceiling under MOPAC PM7 on CI; raise it
-    # so they still have a chance to converge and be reported. Both are
-    # documented non-convergers in reference.json (mopac_pm7_steps=null)
-    # so the regression gate ignores them either way. zn_edta also needs
-    # ~119 steps to converge once the generalised linear-bend trigger
-    # (PR #104) rebuilds around the Zn centre several times; keep the
-    # ceiling above that.
-    berny = Berny(geom, maxsteps=130, trace=trace)
-    solver = MopacSolver(charge=ref['charge'], mult=ref['mult'])
-    energies = _optimize_recording_energies(berny, solver)
-    return berny.converged, berny._n, energies
-
-
 def run_xtb(name, ref, data_dir, trace=None):
     from berny.solvers import XTBSolver
 
     geom = geomlib.readfile(str(data_dir / f'{name}.xyz'))
-    # Match the generous ceiling used for MOPAC so slow convergers are still
-    # reported rather than counted as failures.
+    # Raise the ceiling above pyberny's default 100 steps so slow convergers
+    # are still reported rather than counted as failures. zn_edta, for
+    # instance, needs ~119 steps to converge once the generalised linear-bend
+    # trigger (PR #104) rebuilds around the Zn centre several times.
     berny = Berny(geom, maxsteps=130, trace=trace)
     solver = XTBSolver(charge=ref['charge'], mult=ref['mult'])
     energies = _optimize_recording_energies(berny, solver)
@@ -150,7 +134,7 @@ def run_xtb(name, ref, data_dir, trace=None):
 
 
 def run_one(name, ref, kind, data_dir, trace_dir=None, benchmark=None):
-    runner = {'pyscf': run_pyscf, 'mopac': run_mopac, 'xtb': run_xtb}[kind]
+    runner = {'pyscf': run_pyscf, 'xtb': run_xtb}[kind]
     trace_path = None
     if trace_dir is not None:
         trace_dir.mkdir(parents=True, exist_ok=True)
@@ -181,10 +165,7 @@ def run_one(name, ref, kind, data_dir, trace_dir=None, benchmark=None):
 
 
 REF_STEPS_KEY = {
-    'mopac': 'mopac_pm7_steps',
     'pyscf': 'pyberny_steps',
-    # No reference step counts are populated yet; the column reports measured
-    # steps without gating until stable values are recorded (see CLAUDE.md).
     'xtb': 'xtb_gfn2_steps',
 }
 
@@ -259,7 +240,7 @@ def regression_reason(row, ref):
 
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument('--solver', choices=['pyscf', 'mopac', 'xtb'], required=True)
+    ap.add_argument('--solver', choices=['pyscf', 'xtb'], default='xtb')
     ap.add_argument(
         '--benchmark',
         choices=sorted(BENCHMARKS),
@@ -289,8 +270,6 @@ def main(argv=None):
     )
     args = ap.parse_args(argv)
 
-    if args.solver == 'mopac' and not shutil.which('mopac'):
-        raise SystemExit('mopac not on PATH')
     if args.solver == 'xtb' and importlib.util.find_spec('tblite') is None:
         raise SystemExit(
             'tblite package not installed (pip install pyberny[benchmark])'
@@ -330,10 +309,10 @@ def main(argv=None):
     if errors:
         print(errors, end='')
 
-    # Treat documented-null reference entries (e.g. MOPAC's one
-    # known non-converger) as expected rather than failing the run. A
-    # missing key (no baseline recorded yet for this solver, as with
-    # xtb) is likewise treated as null and skips the gate.
+    # Treat documented-null reference entries (e.g. the xTB flat-minimum
+    # non-reproducers) as expected rather than failing the run. A missing
+    # key (no baseline recorded yet for this solver) is likewise treated as
+    # null and skips the gate.
     ref_key = REF_STEPS_KEY[args.solver]
     regressions = [
         (row['name'], regression_reason(row, reference[row['name']].get(ref_key)))

--- a/scripts/convert_baker_si.py
+++ b/scripts/convert_baker_si.py
@@ -152,7 +152,6 @@ def main(argv=None):
                 'paper_steps': paper_steps,
                 'paper_steps_method': 'HF',
                 'paper_steps_basis': '6-31G**',
-                'mopac_pm7_steps': None,
                 'pyberny_steps': None,
             }
             print(f'wrote {xyz_path.name}  ({len(atoms)} atoms, paper={paper_steps})')
@@ -162,7 +161,6 @@ def main(argv=None):
         'paper_steps',
         'paper_steps_method',
         'paper_steps_basis',
-        'mopac_pm7_steps',
         'pyberny_steps',
     )
     if ref_path.exists():

--- a/scripts/molecule_gallery.html
+++ b/scripts/molecule_gallery.html
@@ -181,7 +181,7 @@
                 ')',
             ],
             ['PyBerny steps', dash(mol.pyberny_steps)],
-            ['MOPAC PM7 steps', dash(mol.mopac_pm7_steps)],
+            ['xTB GFN2 steps', dash(mol.xtb_gfn2_steps)],
           ];
           fields.forEach(function (field) {
             var span = document.createElement('span');

--- a/scripts/molecule_gallery.py
+++ b/scripts/molecule_gallery.py
@@ -44,7 +44,7 @@ def collect_molecules(data_dir):
                 'paper_steps_method': meta['paper_steps_method'],
                 'paper_steps_basis': meta['paper_steps_basis'],
                 'pyberny_steps': meta['pyberny_steps'],
-                'mopac_pm7_steps': meta['mopac_pm7_steps'],
+                'xtb_gfn2_steps': meta['xtb_gfn2_steps'],
                 'xyz': (data_dir / f'{mol_id}.xyz').read_text(),
             }
         )

--- a/scripts/plan_batches.py
+++ b/scripts/plan_batches.py
@@ -5,11 +5,10 @@
 with the package under :mod:`berny.benchmarks`.
 
 For each solver, this script times one energy+gradient call per molecule
-(``mopac`` with ``1SCF GRADIENTS``; ``pyscf`` with one SCF + analytic
-gradient; ``xtb`` with one GFN2-xTB singlepoint through tblite), multiplies by
-the pyberny step count from ``reference.json``, and prints a YAML fragment ready
-to paste into the ``strategy.matrix.include`` block of
-``.github/workflows/benchmark.yaml``.
+(``xtb`` with one GFN2-xTB singlepoint through tblite; ``pyscf`` with one SCF +
+analytic gradient), multiplies by the pyberny step count from
+``reference.json``, and prints a YAML fragment ready to paste into the
+``strategy.matrix.include`` block of ``.github/workflows/benchmark.yaml``.
 
 The per-call timing is the only cost source — there is no analytical
 N**p fallback. Per-iteration cost varies by an order of magnitude across
@@ -17,11 +16,11 @@ this dataset (``easc`` with Al/Cl is ~35x slower than CHNO organics of
 similar size), and no closed-form expression in ``atoms`` captures it.
 
 Step counts come from each solver's column in ``reference.json``
-(``mopac_pm7_steps`` / ``pyberny_steps`` / ``xtb_gfn2_steps``). Where that is
-``null`` for a molecule (a documented non-converger, e.g. ``azadirachtin`` /
-``raffinose`` under mopac) the fallback in ``FALLBACK_STEPS_KEY`` is used --
-``paper_steps`` for pyscf and xtb -- and if that too is missing the median over
-the rest stands in, so a single gap never bottlenecks planning.
+(``xtb_gfn2_steps`` / ``pyberny_steps``). Where that is ``null`` for a molecule
+(a documented non-reproducer, e.g. ``bisphenol_a`` / ``maltose`` under xtb) the
+fallback in ``FALLBACK_STEPS_KEY`` (``paper_steps``) is used -- and if that too
+is missing the median over the rest stands in, so a single gap never
+bottlenecks planning.
 
 Bin-packing: Longest-Processing-Time-first (LPT). ``--nbins`` defaults
 to ``ceil(total / max_single)`` so the heaviest molecule does not
@@ -42,11 +41,8 @@ import glob
 import json
 import math
 import os
-import shutil
 import statistics
-import subprocess
 import sys
-import tempfile
 import time
 from pathlib import Path
 
@@ -64,17 +60,15 @@ from berny.benchmarks import BENCHMARKS, data_dir as _bench_data_dir
 DATA = _bench_data_dir('birkholz')
 
 STEPS_KEY = {
-    'mopac': 'mopac_pm7_steps',
     'pyscf': 'pyberny_steps',
     'xtb': 'xtb_gfn2_steps',
 }
 # Used only if STEPS_KEY value is null for a given molecule.
 FALLBACK_STEPS_KEY = {
-    'mopac': 'mopac_pm7_steps',
     'pyscf': 'paper_steps',
     'xtb': 'paper_steps',
 }
-REPEATS = {'mopac': 3, 'pyscf': 1, 'xtb': 3}
+REPEATS = {'pyscf': 1, 'xtb': 3}
 
 
 def _pin_threads():
@@ -92,30 +86,6 @@ def _pin_threads():
     n = str(len(ids) or os.cpu_count() or 1)
     for v in ('OMP_NUM_THREADS', 'MKL_NUM_THREADS', 'OPENBLAS_NUM_THREADS'):
         os.environ.setdefault(v, n)
-
-
-def _measure_mopac(name, ref):
-    from berny import geomlib
-
-    geom = geomlib.readfile(str(DATA / f'{name}.xyz'))
-    atoms = list(geom)
-    mults = {1: '', 2: 'DOUBLET', 3: 'TRIPLET', 4: 'QUARTET', 5: 'QUINTET'}
-    kw = ['PM7', '1SCF', 'GRADIENTS']
-    if ref['charge']:
-        kw.append(f'CHARGE={ref["charge"]}')
-    if mults[ref['mult']]:
-        kw += [mults[ref['mult']], 'UHF']
-    body = (
-        ' '.join(kw)
-        + '\n\n\n'
-        + '\n'.join(f'{el} {x} 1 {y} 1 {z} 1' for el, (x, y, z) in atoms)
-    )
-    with tempfile.TemporaryDirectory() as td:
-        f = Path(td) / 'job.mop'
-        f.write_text(body)
-        t0 = time.perf_counter()
-        subprocess.check_call(['mopac', str(f)], stdout=subprocess.DEVNULL)
-        return time.perf_counter() - t0
 
 
 def _measure_pyscf(name, ref):
@@ -166,7 +136,7 @@ def _measure_xtb(name, ref):
     return time.perf_counter() - t0
 
 
-MEASURE = {'mopac': _measure_mopac, 'pyscf': _measure_pyscf, 'xtb': _measure_xtb}
+MEASURE = {'pyscf': _measure_pyscf, 'xtb': _measure_xtb}
 
 
 def _step_count(ref, solver, fallback):
@@ -269,7 +239,7 @@ def main(argv=None):
         default=None,
         help='reference.json path (default: derived from --benchmark)',
     )
-    ap.add_argument('--solvers', nargs='+', default=['mopac', 'pyscf'])
+    ap.add_argument('--solvers', nargs='+', default=['xtb', 'pyscf'])
     ap.add_argument(
         '--nbins',
         type=int,
@@ -296,8 +266,6 @@ def main(argv=None):
     if args.reference is None:
         args.reference = DATA / 'reference.json'
     _pin_threads()
-    if 'mopac' in args.solvers and not shutil.which('mopac'):
-        raise SystemExit('mopac not on PATH')
     reference = json.loads(args.reference.read_text())
     unknown = [n for n in args.exclude if n not in reference]
     if unknown:

--- a/scripts/plot_convergence.py
+++ b/scripts/plot_convergence.py
@@ -96,9 +96,9 @@ def main(argv=None):
     )
     ap.add_argument(
         '--solver',
-        default='mopac',
+        default='xtb',
         help=(
-            'which solver the shards were run with (default: mopac). Any '
+            'which solver the shards were run with (default: xtb). Any '
             'value is accepted: the plot is built straight from the recorded '
             'energy trajectories, which have the same shape for every runner, '
             'so no per-solver logic gates this script.'

--- a/scripts/split_birkholz_si.py
+++ b/scripts/split_birkholz_si.py
@@ -78,7 +78,6 @@ def main(argv=None):
             'paper_steps': None,
             'paper_steps_method': 'HF',
             'paper_steps_basis': '3-21G',
-            'mopac_pm7_steps': None,
             'pyberny_steps': None,
         }
         print(
@@ -90,7 +89,6 @@ def main(argv=None):
         'paper_steps',
         'paper_steps_method',
         'paper_steps_basis',
-        'mopac_pm7_steps',
         'pyberny_steps',
     )
     if ref_path.exists():

--- a/src/berny/benchmarks/__init__.py
+++ b/src/berny/benchmarks/__init__.py
@@ -24,7 +24,7 @@ Discovery API::
         ...  # drive your optimizer on `geom` and compare against `ref`
 
 The ``BENCHMARKS`` mapping is also re-exported by ``scripts/benchmark.py``,
-which adds PySCF / MOPAC adapters and a markdown reporting harness on top.
+which adds PySCF / xTB adapters and a markdown reporting harness on top.
 
 Resource access goes through :func:`importlib.resources.files`, mirroring
 how ``species-data.csv`` is loaded elsewhere in the package, so

--- a/src/berny/benchmarks/baker_shajan_2023/SOURCE.md
+++ b/src/berny/benchmarks/baker_shajan_2023/SOURCE.md
@@ -58,7 +58,7 @@ trisilacyclohexane\_135, pterin needing a few extra cycles past ASE/Berny's
 
 ``xtb_gfn2_steps`` records the GFN2-xTB step counts (evaluated through the
 ``tblite`` library; see ``berny.solvers.XTBSolver``). All 30 molecules
-converge under xTB within the 130-step ceiling -- so no entry is ``null``.
+converge under xTB within the default 100-step ceiling -- so no entry is ``null``.
 Unlike three flat-minimum molecules in the ``birkholz_schlegel`` set, every
 Baker molecule's xTB step count is reproducible to 0-1 steps across repeated
 single-host runs. As with PySCF, those counts are not guaranteed bitwise across

--- a/src/berny/benchmarks/baker_shajan_2023/SOURCE.md
+++ b/src/berny/benchmarks/baker_shajan_2023/SOURCE.md
@@ -48,32 +48,26 @@ therefore drift from the paper's numbers for two independent reasons:
 ``paper_steps`` by up to 7% (with an absolute floor of 2 steps) before
 failing the run -- same rule as the Birkholz-Schlegel benchmark.
 
-``pyberny_steps`` and ``mopac_pm7_steps`` were seeded from the first
-manual workflow_dispatch baseline run (PR #84, baker × both at HF/6-31G\*\*
-through PySCF and PM7 through MOPAC). PySCF reaches the same minimum the
-paper found for every one of the 30 molecules with a total of 208 steps
-vs. the paper's 190 (per-row delta typically ≤1 step, with histidine,
-dimethylpentane, menthone, disilyl\_ether, trisilacyclohexane\_135,
-pterin needing a few extra cycles past ASE/Berny's ``fmax``-only test).
-MOPAC PM7 totals 274 steps over 29 molecules; ``caffeine`` is left
-``null`` because PM7 hits the 110-step ceiling on this molecule, the same
-documented-non-converger convention used by ``bisphenol_a`` in the
-``birkholz_schlegel`` set.
+``pyberny_steps`` was seeded from the first manual workflow_dispatch
+baseline run (PR #84, baker at HF/6-31G\*\* through PySCF). PySCF reaches
+the same minimum the paper found for every one of the 30 molecules with a
+total of 208 steps vs. the paper's 190 (per-row delta typically ≤1 step,
+with histidine, dimethylpentane, menthone, disilyl\_ether,
+trisilacyclohexane\_135, pterin needing a few extra cycles past ASE/Berny's
+``fmax``-only test).
 
 ``xtb_gfn2_steps`` records the GFN2-xTB step counts (evaluated through the
 ``tblite`` library; see ``berny.solvers.XTBSolver``). All 30 molecules
-converge under xTB within the 130-step ceiling -- including ``caffeine``, which
-is a non-converger under PM7 -- so no entry is ``null``. Unlike three
-flat-minimum molecules in the ``birkholz_schlegel`` set, every Baker molecule's
-xTB step count is reproducible to 0-1 steps across repeated single-host runs. As
-with the other solvers, those counts are not guaranteed bitwise across different
-hosts, so the same 7%/2-step drift tolerance applies and the committed
+converge under xTB within the 130-step ceiling -- so no entry is ``null``.
+Unlike three flat-minimum molecules in the ``birkholz_schlegel`` set, every
+Baker molecule's xTB step count is reproducible to 0-1 steps across repeated
+single-host runs. As with PySCF, those counts are not guaranteed bitwise across
+different hosts, so the same 7%/2-step drift tolerance applies and the committed
 single-host baseline should be confirmed from the first CI ``workflow_dispatch``
-xTB run. One GFN2-xTB call on these small organics is
-a few milliseconds, so the whole Baker set is only ~3 s of compute under xTB;
-like ``mopac_pm7_steps`` it runs as a single CI shard (``scripts/plan_batches.py
---benchmark baker --solvers xtb --nbins 1``) -- extra shards would be dominated
-by per-job setup overhead.
+xTB run. One GFN2-xTB call on these small organics is a few milliseconds, so the
+whole Baker set is only ~3 s of compute under xTB; it runs as a single CI shard
+(``scripts/plan_batches.py --benchmark baker --solvers xtb --nbins 1``) -- extra
+shards would be dominated by per-job setup overhead.
 
 Coordinate data is treated as factual and is redistributed under
 pyberny's MPL-2.0 license, with attribution to Shajan et al. via this

--- a/src/berny/benchmarks/baker_shajan_2023/reference.json
+++ b/src/berny/benchmarks/baker_shajan_2023/reference.json
@@ -2,7 +2,6 @@
   "acanil01": {
     "atoms": 19,
     "charge": 0,
-    "mopac_pm7_steps": 39,
     "mult": 1,
     "name": "ACANIL01",
     "paper_steps": 7,
@@ -14,7 +13,6 @@
   "acetone": {
     "atoms": 10,
     "charge": 0,
-    "mopac_pm7_steps": 7,
     "mult": 1,
     "name": "Acetone",
     "paper_steps": 5,
@@ -26,7 +24,6 @@
   "acetylene": {
     "atoms": 4,
     "charge": 0,
-    "mopac_pm7_steps": 9,
     "mult": 1,
     "name": "Acetylene",
     "paper_steps": 5,
@@ -38,7 +35,6 @@
   "achtar10": {
     "atoms": 16,
     "charge": 0,
-    "mopac_pm7_steps": 9,
     "mult": 1,
     "name": "ACHTAR10",
     "paper_steps": 10,
@@ -50,7 +46,6 @@
   "allene": {
     "atoms": 7,
     "charge": 0,
-    "mopac_pm7_steps": 14,
     "mult": 1,
     "name": "Allene",
     "paper_steps": 5,
@@ -62,7 +57,6 @@
   "ammonia": {
     "atoms": 4,
     "charge": 0,
-    "mopac_pm7_steps": 4,
     "mult": 1,
     "name": "Ammonia",
     "paper_steps": 4,
@@ -74,7 +68,6 @@
   "benzaldehyde": {
     "atoms": 14,
     "charge": 0,
-    "mopac_pm7_steps": 5,
     "mult": 1,
     "name": "Benzaldehyde",
     "paper_steps": 7,
@@ -86,7 +79,6 @@
   "benzene": {
     "atoms": 12,
     "charge": 0,
-    "mopac_pm7_steps": 4,
     "mult": 1,
     "name": "Benzene",
     "paper_steps": 3,
@@ -98,7 +90,6 @@
   "benzidine": {
     "atoms": 26,
     "charge": 0,
-    "mopac_pm7_steps": 24,
     "mult": 1,
     "name": "Benzidine",
     "paper_steps": 7,
@@ -110,7 +101,6 @@
   "caffeine": {
     "atoms": 24,
     "charge": 0,
-    "mopac_pm7_steps": null,
     "mult": 1,
     "name": "Caffeine",
     "paper_steps": 10,
@@ -122,7 +112,6 @@
   "difluorobenzene_13": {
     "atoms": 12,
     "charge": 0,
-    "mopac_pm7_steps": 5,
     "mult": 1,
     "name": "1,3-Difluorobenzene",
     "paper_steps": 4,
@@ -134,7 +123,6 @@
   "difluoronaphthalene_15": {
     "atoms": 18,
     "charge": 0,
-    "mopac_pm7_steps": 5,
     "mult": 1,
     "name": "1,5-Difluoronaphthalene",
     "paper_steps": 5,
@@ -146,7 +134,6 @@
   "difuropyrazine": {
     "atoms": 16,
     "charge": 0,
-    "mopac_pm7_steps": 7,
     "mult": 1,
     "name": "Difuropyrazine",
     "paper_steps": 7,
@@ -158,7 +145,6 @@
   "dimethylpentane": {
     "atoms": 23,
     "charge": 0,
-    "mopac_pm7_steps": 10,
     "mult": 1,
     "name": "Dimethylpentane",
     "paper_steps": 6,
@@ -170,7 +156,6 @@
   "disilyl_ether": {
     "atoms": 9,
     "charge": 0,
-    "mopac_pm7_steps": 8,
     "mult": 1,
     "name": "Disilyl ether",
     "paper_steps": 9,
@@ -182,7 +167,6 @@
   "ethane": {
     "atoms": 8,
     "charge": 0,
-    "mopac_pm7_steps": 4,
     "mult": 1,
     "name": "Ethane",
     "paper_steps": 4,
@@ -194,7 +178,6 @@
   "ethanol": {
     "atoms": 9,
     "charge": 0,
-    "mopac_pm7_steps": 5,
     "mult": 1,
     "name": "Ethanol",
     "paper_steps": 5,
@@ -206,7 +189,6 @@
   "furan": {
     "atoms": 9,
     "charge": 0,
-    "mopac_pm7_steps": 5,
     "mult": 1,
     "name": "Furan",
     "paper_steps": 5,
@@ -218,7 +200,6 @@
   "histidine": {
     "atoms": 20,
     "charge": 0,
-    "mopac_pm7_steps": 19,
     "mult": 1,
     "name": "Histidine",
     "paper_steps": 14,
@@ -230,7 +211,6 @@
   "hydroxybicyclopentane_2": {
     "atoms": 14,
     "charge": 0,
-    "mopac_pm7_steps": 9,
     "mult": 1,
     "name": "2-Hydroxybicyclopentane",
     "paper_steps": 9,
@@ -242,7 +222,6 @@
   "hydroxysulfane": {
     "atoms": 4,
     "charge": 0,
-    "mopac_pm7_steps": 6,
     "mult": 1,
     "name": "Hydroxysulfane",
     "paper_steps": 6,
@@ -254,7 +233,6 @@
   "menthone": {
     "atoms": 29,
     "charge": 0,
-    "mopac_pm7_steps": 16,
     "mult": 1,
     "name": "Menthone",
     "paper_steps": 10,
@@ -266,7 +244,6 @@
   "mesityl_oxide": {
     "atoms": 17,
     "charge": 0,
-    "mopac_pm7_steps": 8,
     "mult": 1,
     "name": "Mesityl oxide",
     "paper_steps": 7,
@@ -278,7 +255,6 @@
   "methylamine": {
     "atoms": 7,
     "charge": 0,
-    "mopac_pm7_steps": 18,
     "mult": 1,
     "name": "Methylamine",
     "paper_steps": 4,
@@ -290,7 +266,6 @@
   "naphthalene": {
     "atoms": 18,
     "charge": 0,
-    "mopac_pm7_steps": 5,
     "mult": 1,
     "name": "Naphthalene",
     "paper_steps": 5,
@@ -302,7 +277,6 @@
   "neopentane": {
     "atoms": 17,
     "charge": 0,
-    "mopac_pm7_steps": 4,
     "mult": 1,
     "name": "Neopentane",
     "paper_steps": 4,
@@ -314,7 +288,6 @@
   "pterin": {
     "atoms": 17,
     "charge": 0,
-    "mopac_pm7_steps": 8,
     "mult": 1,
     "name": "Pterin",
     "paper_steps": 11,
@@ -326,7 +299,6 @@
   "trifluorobenzene_135": {
     "atoms": 12,
     "charge": 0,
-    "mopac_pm7_steps": 4,
     "mult": 1,
     "name": "1,3,5-Trifluorobenzene",
     "paper_steps": 4,
@@ -338,7 +310,6 @@
   "trisilacyclohexane_135": {
     "atoms": 18,
     "charge": 0,
-    "mopac_pm7_steps": 7,
     "mult": 1,
     "name": "1,3,5-Trisilacyclohexane",
     "paper_steps": 4,
@@ -350,7 +321,6 @@
   "water": {
     "atoms": 3,
     "charge": 0,
-    "mopac_pm7_steps": 5,
     "mult": 1,
     "name": "Water",
     "paper_steps": 4,

--- a/src/berny/benchmarks/birkholz_schlegel/SOURCE.md
+++ b/src/berny/benchmarks/birkholz_schlegel/SOURCE.md
@@ -37,7 +37,7 @@ within the 100-step default ceiling.
 
 ``xtb_gfn2_steps`` records the GFN2-xTB step counts (evaluated through the
 ``tblite`` library; see ``berny.solvers.XTBSolver``). All 19 molecules *converge*
-under xTB within the benchmark's 130-step ceiling -- including ``ochratoxin_a``,
+under xTB within the default 100-step ceiling -- including ``ochratoxin_a``,
 which does not converge under PySCF. A single GFN2-xTB energy+gradient call is
 sub-second even for the 95-atom ``azadirachtin`` (~0.75 s), so unlike PySCF
 nothing has to be excluded on cost grounds.

--- a/src/berny/benchmarks/birkholz_schlegel/SOURCE.md
+++ b/src/berny/benchmarks/birkholz_schlegel/SOURCE.md
@@ -24,27 +24,9 @@ benchmark.
 ``paper_steps`` (from Table 1, "Standard" column) for each molecule, along
 with the QM ``paper_steps_method`` and ``paper_steps_basis`` used for that
 row (HF/3-21G for all molecules except EASC and Vitamin C, which use
-B3LYP/6-31G(d,p)). The ``pyberny_steps``, ``mopac_pm7_steps`` and
-``xtb_gfn2_steps`` fields are populated by running ``scripts/benchmark.py`` and
-committing the measured counts as a regression baseline.
-
-``mopac_pm7_steps`` is left ``null`` for ``azadirachtin`` and ``raffinose``:
-both have very flat minima where, once ``MopacSolver`` switched to the
-high-precision ``AUX`` file (lowering the energy noise floor by ~1000×), the
-discrete Fletcher trust-radius rule reacts to the real ~1e-6 Ha energy
-changes and limit-cycles on the trust-region sphere at the minimum.
-``azadirachtin`` never satisfies the step-convergence criteria within the
-benchmark's 130-step ceiling; ``raffinose`` does eventually converge, but at a
-step count that is not reproducible across hosts (e.g. 76 vs 87 on otherwise
-identical GitHub Actions runs), so it has no meaningful baseline to gate on.
-Both are documented non-convergers rather than a regression: the flat-minimum
-sawtooth is orthogonal to this AUX/noise-floor change and is addressed
-separately by the sphere-convergence gate, not by ``energy_noise``. The
-reference values come from a run on GitHub Actions' ``ubuntu-latest`` (MOPAC
-23.2.5, BLAS threads pinned to the runner's physical-core count); MOPAC PM7 is
-not bitwise-reproducible across hosts, so ``scripts/benchmark.py`` and
-``scripts/aggregate_benchmark.py`` allow each row to drift from its reference
-by up to 7% (with an absolute floor of 2 steps) before failing the run.
+B3LYP/6-31G(d,p)). The ``pyberny_steps`` and ``xtb_gfn2_steps`` fields are
+populated by running ``scripts/benchmark.py`` and committing the measured
+counts as a regression baseline.
 
 ``pyberny_steps`` records the PySCF step counts from a GitHub Actions run
 using the method and basis in ``paper_steps_method``/``paper_steps_basis``
@@ -55,8 +37,7 @@ within the 100-step default ceiling.
 
 ``xtb_gfn2_steps`` records the GFN2-xTB step counts (evaluated through the
 ``tblite`` library; see ``berny.solvers.XTBSolver``). All 19 molecules *converge*
-under xTB within the benchmark's 130-step ceiling -- including ``azadirachtin``
-and ``raffinose``, documented non-convergers under PM7, and ``ochratoxin_a``,
+under xTB within the benchmark's 130-step ceiling -- including ``ochratoxin_a``,
 which does not converge under PySCF. A single GFN2-xTB energy+gradient call is
 sub-second even for the 95-atom ``azadirachtin`` (~0.75 s), so unlike PySCF
 nothing has to be excluded on cost grounds.
@@ -67,10 +48,9 @@ reproducible: ``tblite``'s OpenMP reductions are not bitwise-deterministic, and
 near a flat minimum the resulting ~1e-9 Ha noise reroutes the trust-radius path,
 so repeated runs on a *single* host already scatter well past the 7%/2-step gate
 (``bisphenol_a`` ranged 63-85 over four runs; ``penicillin_v`` 52-64;
-``maltose`` 76-86). They are the xTB analogue of ``raffinose``/``azadirachtin``
-under PM7 and have no meaningful value to gate on. The other 16 molecules are
-reproducible to 0-1 steps across runs. Like PM7, even those stable counts are
-not guaranteed bitwise across *different* hosts, so the same 7%/2-step drift
+``maltose`` 76-86), so they have no meaningful value to gate on. The other 16
+molecules are reproducible to 0-1 steps across runs. Even those stable counts
+are not guaranteed bitwise across *different* hosts, so the same 7%/2-step drift
 tolerance applies; the committed values are a single-host baseline and should be
 confirmed (and refreshed if needed) from the first CI ``workflow_dispatch`` xTB
 run.

--- a/src/berny/benchmarks/birkholz_schlegel/SOURCE.md
+++ b/src/berny/benchmarks/birkholz_schlegel/SOURCE.md
@@ -58,9 +58,8 @@ run.
 xTB needs no fast/full batch split (no easc-style per-call outlier to
 quarantine): ``scripts/plan_batches.py`` bins it into four cost-balanced shards
 (per-call ``tblite`` time × ``xtb_gfn2_steps``, falling back to ``paper_steps``
-for the three ``null`` rows) used for both ``birkholz-fast`` and
-``birkholz-full``. The ``null`` molecules still *run* in those shards; only the
-regression gate skips them.
+for the three ``null`` rows). The ``null`` molecules still *run* in those
+shards; only the regression gate skips them.
 
 Coordinate data is treated as factual and is redistributed under pyberny's
 MPL-2.0 license, with attribution to Birkholz & Schlegel via this file and

--- a/src/berny/benchmarks/birkholz_schlegel/reference.json
+++ b/src/berny/benchmarks/birkholz_schlegel/reference.json
@@ -2,7 +2,6 @@
   "artemisinin": {
     "atoms": 42,
     "charge": 0,
-    "mopac_pm7_steps": 25,
     "mult": 1,
     "name": "Artemisinin",
     "paper_steps": 24,
@@ -14,7 +13,6 @@
   "avobenzone": {
     "atoms": 45,
     "charge": 0,
-    "mopac_pm7_steps": 90,
     "mult": 1,
     "name": "Avobenzone",
     "paper_steps": 43,
@@ -26,7 +24,6 @@
   "azadirachtin": {
     "atoms": 95,
     "charge": 0,
-    "mopac_pm7_steps": null,
     "mult": 1,
     "name": "Azadirachtin",
     "paper_steps": 77,
@@ -38,7 +35,6 @@
   "bisphenol_a": {
     "atoms": 33,
     "charge": 0,
-    "mopac_pm7_steps": 45,
     "mult": 1,
     "name": "Bisphenol A",
     "paper_steps": 31,
@@ -50,7 +46,6 @@
   "cetirizine": {
     "atoms": 52,
     "charge": 0,
-    "mopac_pm7_steps": 57,
     "mult": 1,
     "name": "Cetirizine",
     "paper_steps": 35,
@@ -62,7 +57,6 @@
   "codeine": {
     "atoms": 43,
     "charge": 0,
-    "mopac_pm7_steps": 31,
     "mult": 1,
     "name": "Codeine",
     "paper_steps": 18,
@@ -74,7 +68,6 @@
   "diisobutyl_phthalate": {
     "atoms": 42,
     "charge": 0,
-    "mopac_pm7_steps": 38,
     "mult": 1,
     "name": "Diisobutyl phthalate",
     "paper_steps": 27,
@@ -86,7 +79,6 @@
   "easc": {
     "atoms": 26,
     "charge": 0,
-    "mopac_pm7_steps": 53,
     "mult": 1,
     "name": "EASC",
     "paper_steps": 40,
@@ -98,7 +90,6 @@
   "estradiol": {
     "atoms": 44,
     "charge": 0,
-    "mopac_pm7_steps": 27,
     "mult": 1,
     "name": "Estradiol",
     "paper_steps": 21,
@@ -110,7 +101,6 @@
   "inosine_cation": {
     "atoms": 31,
     "charge": 1,
-    "mopac_pm7_steps": 47,
     "mult": 1,
     "name": "Inosine",
     "paper_steps": 41,
@@ -122,7 +112,6 @@
   "maltose": {
     "atoms": 45,
     "charge": 0,
-    "mopac_pm7_steps": 54,
     "mult": 1,
     "name": "Maltose",
     "paper_steps": 35,
@@ -134,7 +123,6 @@
   "mg_porphin": {
     "atoms": 37,
     "charge": 0,
-    "mopac_pm7_steps": 32,
     "mult": 1,
     "name": "Mg Porphin",
     "paper_steps": 14,
@@ -146,7 +134,6 @@
   "ochratoxin_a": {
     "atoms": 45,
     "charge": 0,
-    "mopac_pm7_steps": 59,
     "mult": 1,
     "name": "Ochratoxin A",
     "paper_steps": 31,
@@ -158,7 +145,6 @@
   "penicillin_v": {
     "atoms": 42,
     "charge": 0,
-    "mopac_pm7_steps": 54,
     "mult": 1,
     "name": "Penicillin V",
     "paper_steps": 31,
@@ -170,7 +156,6 @@
   "raffinose": {
     "atoms": 66,
     "charge": 0,
-    "mopac_pm7_steps": null,
     "mult": 1,
     "name": "Raffinose",
     "paper_steps": 53,
@@ -182,7 +167,6 @@
   "sphingomyelin": {
     "atoms": 84,
     "charge": 0,
-    "mopac_pm7_steps": 89,
     "mult": 1,
     "name": "Sphingomyelin",
     "paper_steps": 56,
@@ -194,7 +178,6 @@
   "tamoxifen": {
     "atoms": 57,
     "charge": 0,
-    "mopac_pm7_steps": 72,
     "mult": 1,
     "name": "Tamoxifen",
     "paper_steps": 35,
@@ -206,7 +189,6 @@
   "vitamin_c": {
     "atoms": 20,
     "charge": 0,
-    "mopac_pm7_steps": 29,
     "mult": 1,
     "name": "Vitamin C",
     "paper_steps": 18,
@@ -218,7 +200,6 @@
   "zn_edta": {
     "atoms": 33,
     "charge": -2,
-    "mopac_pm7_steps": 117,
     "mult": 1,
     "name": "Zn EDTA",
     "paper_steps": 29,

--- a/src/berny/geomlib.py
+++ b/src/berny/geomlib.py
@@ -100,8 +100,7 @@ class Geometry:
         """Save the geometry into a file.
 
         :param file f: file object
-        :param str fmt: geometry format, one of ``""``, ``"xyz"``, ``"aims"``,
-            ``"mopac"``.
+        :param str fmt: geometry format, one of ``""``, ``"xyz"``, ``"aims"``.
         """
         if fmt == '':
             f.write(repr(self))
@@ -120,11 +119,6 @@ class Geometry:
             for specie, coord in self:
                 coords_str = ' '.join(f'{x:15.8}' for x in coord)
                 f.write(f'atom {coords_str} {specie:>2}\n')
-        elif fmt == 'mopac':
-            f.write(f'* Formula: {self.formula}\n')
-            for specie, coord in self:
-                coords_str = ' '.join(f'{x:15.8} 1' for x in coord)
-                f.write(f'{specie:>2} {coords_str}\n')
         else:
             raise ValueError(f'Unknown format: {fmt!r}')
 
@@ -147,8 +141,6 @@ class Geometry:
             fmt = 'xyz'
         elif ext == '.aims' or os.path.basename(filename) == 'geometry.in':
             fmt = 'aims'
-        elif ext == '.mopac':
-            fmt = 'mopac'
         else:
             raise ValueError('Unknown file extension')
         with open(filename, 'w') as f:

--- a/src/berny/optimize.py
+++ b/src/berny/optimize.py
@@ -26,7 +26,7 @@ def optimize(
             yields the energy and gradients (as a :math:`N`-by-3 matrix or
             :math:`(N+3)`-by-3 matrix in case of a crystal geometry).
 
-            See :class:`~berny.solvers.MopacSolver` for an example.
+            See :class:`~berny.solvers.XTBSolver` for an example.
         trajectory: filename for the XYZ trajectory
 
     Returns:

--- a/src/berny/solvers.py
+++ b/src/berny/solvers.py
@@ -2,10 +2,6 @@
 # http://creativecommons.org/publicdomain/zero/1.0/
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
-import tempfile
 from collections.abc import Callable, Generator
 from typing import Any, Optional
 
@@ -15,7 +11,7 @@ from numpy.typing import NDArray
 from .coords import angstrom
 from .species_data import get_property
 
-__all__ = ['MopacSolver', 'XTBSolver']
+__all__ = ['XTBSolver']
 
 FloatArray = NDArray[np.floating[Any]]
 
@@ -29,109 +25,6 @@ SolverInput = tuple[list[tuple[str, FloatArray]], Optional[FloatArray]]  # noqa:
 SolverOutput = tuple[float, FloatArray]
 #: Generator type of a solver — yields ``None`` once before the first send.
 Solver = Generator[Optional[SolverOutput], SolverInput, None]  # noqa: UP045
-
-
-_MOPAC_MULT_KEYWORDS = {
-    1: '',
-    2: 'DOUBLET',
-    3: 'TRIPLET',
-    4: 'QUARTET',
-    5: 'QUINTET',
-    6: 'SEXTET',
-    7: 'SEPTET',
-}
-
-
-def _mopac_keyword_line(method: str, charge: int, mult: int) -> str:
-    """Build the MOPAC keyword line for a single-point gradient run."""
-    try:
-        mult_kw = _MOPAC_MULT_KEYWORDS[mult]
-    except KeyError as e:
-        raise ValueError(f'unsupported MOPAC multiplicity: {mult}') from e
-    keywords = [method, '1SCF', 'GRADIENTS', 'AUX(PRECISION=9)']
-    if charge:
-        keywords.append(f'CHARGE={charge}')
-    if mult_kw:
-        keywords += [mult_kw, 'UHF']
-    return ' '.join(keywords)
-
-
-def _parse_mopac_aux(path: str, n_grad: int) -> tuple[float, FloatArray]:
-    """Parse the energy and gradients from a MOPAC ``AUX`` file.
-
-    The ``AUX`` file carries the heat of formation to 15 significant figures
-    (vs. ``1e-5 kcal/mol`` print quantization in the ``.out`` file) and the
-    gradients to higher precision, both as flat whitespace-separated lists in
-    a Fortran ``D`` exponent format. ``n_grad`` is the expected number of
-    gradient components (``3`` per atom and lattice vector).
-    """
-    energy: float | None = None
-    with open(path) as f:
-        lines = iter(f)
-        for line in lines:
-            if line.startswith(' HEAT_OF_FORMATION:KCAL/MOL='):
-                energy = float(line.split('=', 1)[1].replace('D', 'E'))
-            elif line.startswith(' GRADIENTS:KCAL/MOL/ANGSTROM'):
-                if energy is None:
-                    raise ValueError('no HEAT_OF_FORMATION found in MOPAC AUX file')
-                values: list[float] = []
-                for grad_line in lines:
-                    values += [float(t.replace('D', 'E')) for t in grad_line.split()]
-                    if len(values) >= n_grad:
-                        return energy, np.array(values[:n_grad]).reshape(-1, 3)
-                raise ValueError(
-                    'MOPAC AUX GRADIENTS block is truncated: expected '
-                    f'{n_grad} gradient components, found {len(values)} '
-                    '(MOPAC likely failed or was interrupted)'
-                )
-    raise ValueError('no GRADIENTS found in MOPAC AUX file')
-
-
-def MopacSolver(
-    cmd: str = 'mopac',
-    method: str = 'PM7',
-    workdir: str | None = None,
-    *,
-    charge: int = 0,
-    mult: int = 1,
-) -> Solver:
-    """
-    Crate a solver that wraps `MOPAC <http://openmopac.net>`_.
-
-    Mopac needs to be installed on the system.
-
-    :param str cmd: MOPAC executable
-    :param str method: model to calculate energy
-    :param workdir: directory for MOPAC scratch files (default: a tempdir)
-    :param int charge: total charge (keyword-only)
-    :param int mult: spin multiplicity, keyword-only (1 = singlet, 2 = doublet,
-        ...); values > 1 also switch MOPAC to UHF
-    """
-    keyword_line = _mopac_keyword_line(method, charge, mult)
-    kcal = 1 / 627.503
-    tmpdir = workdir or tempfile.mkdtemp()
-    try:
-        atoms, lattice = yield None
-        while True:
-            mopac_input = f'{keyword_line}\n\n\n' + '\n'.join(
-                f'{el} {x} 1 {y} 1 {z} 1' for el, (x, y, z) in atoms
-            )
-            if lattice is not None:
-                mopac_input += '\n' + '\n'.join(
-                    f'Tv {x} 1 {y} 1 {z} 1' for x, y, z in lattice
-                )
-            input_file = os.path.join(tmpdir, 'job.mop')
-            with open(input_file, 'w') as f:
-                f.write(mopac_input)
-            subprocess.check_call([cmd, input_file])
-            n_grad = 3 * (len(atoms) + (0 if lattice is None else 3))
-            energy, gradients = _parse_mopac_aux(
-                os.path.join(tmpdir, 'job.aux'), n_grad
-            )
-            atoms, lattice = yield energy * kcal, gradients * kcal / angstrom
-    finally:
-        if tmpdir != workdir:
-            shutil.rmtree(tmpdir)
 
 
 #: Maps an ``XTBSolver`` method name to the corresponding ``tblite`` method.
@@ -179,7 +72,7 @@ def _tblite_singlepoint(
     """Run a single tblite energy+gradient evaluation via the Python bindings.
 
     Energy (Hartree) and gradient (Hartree/bohr) come back in atomic units and
-    are returned unchanged -- no unit conversion, unlike :func:`MopacSolver`.
+    are returned unchanged -- no unit conversion needed.
     """
     try:
         from tblite.interface import Calculator
@@ -212,9 +105,8 @@ def XTBSolver(
     <https://tblite.readthedocs.io>`_ library.
 
     The ``tblite`` package must be installed (``pip install pyberny[benchmark]``).
-    Unlike :func:`MopacSolver`, GFN2-xTB has a smooth potential-energy surface,
-    which makes it a useful alternative semiempirical backend near flat minima
-    where PM7 can be effectively discontinuous.
+    GFN2-xTB has a smooth potential-energy surface, which makes it well behaved
+    even near flat minima.
 
     :param str method: xTB parametrisation -- ``'gfn2'`` (default), ``'gfn1'``
         or ``'ipea1'``

--- a/tests/test_geomlib.py
+++ b/tests/test_geomlib.py
@@ -33,18 +33,6 @@ def test_xyz_round_trip():
     assert g2.lattice is None
 
 
-def test_mopac_dump_contains_atoms_with_flags():
-    # mopac is dump-only (load doesn't accept it). Just check the output
-    # has one line per atom with the trailing `1` optimization flags.
-    g = Geometry(['H', 'H'], [[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
-    out = format(g, 'mopac').splitlines()
-    assert out[0].startswith('*')
-    assert len(out) == 1 + len(g)
-    # Each line: symbol x 1 y 1 z 1
-    assert out[1].split()[0] == 'H'
-    assert out[1].split()[-1] == '1'
-
-
 def test_dump_empty_format_uses_repr():
     g = Geometry(['H'], [[0.0, 0.0, 0.0]])
     assert format(g, '') == repr(g)
@@ -99,17 +87,13 @@ def test_write_dispatches_by_extension(tmp_path):
     xyz = tmp_path / 'mol.xyz'
     aims = tmp_path / 'mol.aims'
     geom_in = tmp_path / 'geometry.in'
-    mop = tmp_path / 'mol.mopac'
     g.write(str(xyz))
     g.write(str(aims))
     g.write(str(geom_in))
-    g.write(str(mop))
-    # Round-trip the two formats that can be loaded.
+    # Round-trip the formats that can be loaded.
     assert loads(xyz.read_text(), 'xyz').species == g.species
     assert loads(aims.read_text(), 'aims').species == g.species
     assert loads(geom_in.read_text(), 'aims').species == g.species
-    # mopac is dump-only — just check it produced something starting with `*`.
-    assert mop.read_text().startswith('*')
 
 
 def test_write_unknown_extension_raises(tmp_path):

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from berny import Berny, geomlib, optimize
-from berny.solvers import MopacSolver, XTBSolver
+from berny.solvers import XTBSolver
 
 XYZ_DIR = Path(__file__).parent
 
@@ -14,63 +14,43 @@ xtb_required = pytest.mark.skipif(
 
 
 @pytest.fixture
-def mopac():
-    return MopacSolver()
-
-
-@pytest.fixture
 def xtb():
     return XTBSolver()
 
 
 def ethanol():
-    return geomlib.readfile(str(XYZ_DIR / 'ethanol.xyz')), 5
+    return geomlib.readfile(str(XYZ_DIR / 'ethanol.xyz'))
 
 
 def aniline():
-    return geomlib.readfile(str(XYZ_DIR / 'aniline.xyz')), 12
+    return geomlib.readfile(str(XYZ_DIR / 'aniline.xyz'))
 
 
 def cyanogen():
-    return geomlib.readfile(str(XYZ_DIR / 'cyanogen.xyz')), 4
+    return geomlib.readfile(str(XYZ_DIR / 'cyanogen.xyz'))
 
 
 def water():
-    return geomlib.readfile(str(XYZ_DIR / 'water.xyz')), 7
-
-
-@pytest.mark.parametrize('test_case', [ethanol, aniline, cyanogen, water])
-def test_optimize(mopac, test_case):
-    geom, n_ref = test_case()
-    berny = Berny(geom)
-    optimize(berny, mopac)
-    assert berny.converged
-    # n_ref is the historical exact step count. We allow a small drift so
-    # that algorithmic tweaks that change the iteration trajectory by one or
-    # two steps don't break the integration tests; a real regression that
-    # blows up the optimizer past this band will still be caught.
-    assert (
-        berny._n <= n_ref + 2
-    ), f'converged in {berny._n} steps, more than the {n_ref} + 2 band'
+    return geomlib.readfile(str(XYZ_DIR / 'water.xyz'))
 
 
 @xtb_required
 @pytest.mark.parametrize('test_case', [ethanol, aniline, cyanogen, water])
-def test_optimize_xtb(xtb, test_case):
-    # GFN2-xTB step counts differ from PM7 and aren't pinned to a historical
-    # baseline, so we only assert that the optimization converges (within a
-    # generous ceiling) through the same coroutine path as MopacSolver.
-    geom, _ = test_case()
+def test_optimize(xtb, test_case):
+    # GFN2-xTB step counts aren't pinned to a historical baseline, so we only
+    # assert that the optimization converges within a generous ceiling.
+    geom = test_case()
     berny = Berny(geom, maxsteps=100)
     optimize(berny, xtb)
     assert berny.converged
 
 
-def test_optimize_writes_trajectory(mopac, tmp_path):
-    geom, _ = water()
-    berny = Berny(geom)
+@xtb_required
+def test_optimize_writes_trajectory(xtb, tmp_path):
+    geom = water()
+    berny = Berny(geom, maxsteps=100)
     traj = tmp_path / 'traj.xyz'
-    optimize(berny, mopac, trajectory=str(traj))
+    optimize(berny, xtb, trajectory=str(traj))
     assert berny.converged
     # One XYZ frame per optimizer step. Each frame is atom_count + comment +
     # N atom lines = N + 2 lines.

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -9,102 +9,9 @@ from berny.solvers import (
     GenericSolver,
     XTBSolver,
     _diff5,
-    _mopac_keyword_line,
-    _parse_mopac_aux,
     _tblite_geometry,
     _tblite_method,
 )
-
-# A trimmed MOPAC AUX file for water (PM7 1SCF GRADIENTS AUX(PRECISION=9)).
-# Energy and gradients are printed in Fortran ``D`` exponent format and to
-# 15 significant figures -- far finer than the ``1e-5 kcal/mol`` quantization
-# of the ``.out`` file the solver used to parse.
-_WATER_AUX = """\
- HEAT_OF_FORMATION:KCAL/MOL=-0.577822806548975D+02
- GRADIENT_NORM:KCAL/MOL/ANGSTROM=+0.546567360177825D+01
- ATOM_X_OPT:ANGSTROMS[09]=
-    0.0000000000000    0.0000000000000    0.0000000000000
- GRADIENTS:KCAL/MOL/ANGSTROM[09]=
-  -3.4312143657544   0.0000000507512  -2.3676270992310   0.7963817277085 \
-   0.0000000252344   2.2122353896105   2.6348324481675   0.0000000251599 \
-   0.1553914772902
- CPU_TIME:SECONDS[1]=        0.01
-"""
-
-
-def test_parse_mopac_aux(tmp_path):
-    aux = tmp_path / 'job.aux'
-    aux.write_text(_WATER_AUX)
-    energy, gradients = _parse_mopac_aux(str(aux), 9)
-    assert energy == pytest.approx(-57.7822806548975, abs=0)
-    assert gradients.shape == (3, 3)
-    np.testing.assert_allclose(
-        gradients,
-        [
-            [-3.4312143657544, 0.0000000507512, -2.3676270992310],
-            [0.7963817277085, 0.0000000252344, 2.2122353896105],
-            [2.6348324481675, 0.0000000251599, 0.1553914772902],
-        ],
-    )
-
-
-def test_parse_mopac_aux_missing_gradients(tmp_path):
-    aux = tmp_path / 'job.aux'
-    aux.write_text(' HEAT_OF_FORMATION:KCAL/MOL=-0.577822806548975D+02\n')
-    with pytest.raises(ValueError, match='no GRADIENTS'):
-        _parse_mopac_aux(str(aux), 9)
-
-
-def test_parse_mopac_aux_truncated_gradients(tmp_path):
-    # GRADIENTS block present but cut short (MOPAC died mid-write): must raise
-    # a clear, contextual error rather than letting ``next`` exhaust the file
-    # and surface an opaque ``StopIteration``/``RuntimeError`` (see issue #130).
-    aux = tmp_path / 'job.aux'
-    aux.write_text(
-        ' HEAT_OF_FORMATION:KCAL/MOL=-0.577822806548975D+02\n'
-        ' GRADIENTS:KCAL/MOL/ANGSTROM[09]=\n'
-        '  -3.4312143657544   0.0000000507512  -2.3676270992310\n'
-    )
-    with pytest.raises(ValueError, match='truncated'):
-        _parse_mopac_aux(str(aux), 9)
-
-
-def test_parse_mopac_aux_gradients_before_energy(tmp_path):
-    # A GRADIENTS block with no preceding HEAT_OF_FORMATION is malformed.
-    aux = tmp_path / 'job.aux'
-    aux.write_text(' GRADIENTS:KCAL/MOL/ANGSTROM[03]=\n  1.0  2.0  3.0\n')
-    with pytest.raises(ValueError, match='no HEAT_OF_FORMATION'):
-        _parse_mopac_aux(str(aux), 3)
-
-
-def test_mopac_neutral_singlet():
-    assert _mopac_keyword_line('PM7', 0, 1) == 'PM7 1SCF GRADIENTS AUX(PRECISION=9)'
-
-
-def test_mopac_cation():
-    assert (
-        _mopac_keyword_line('PM7', 1, 1)
-        == 'PM7 1SCF GRADIENTS AUX(PRECISION=9) CHARGE=1'
-    )
-
-
-def test_mopac_dianion():
-    assert (
-        _mopac_keyword_line('PM7', -2, 1)
-        == 'PM7 1SCF GRADIENTS AUX(PRECISION=9) CHARGE=-2'
-    )
-
-
-def test_mopac_doublet_cation():
-    assert (
-        _mopac_keyword_line('PM7', 1, 2)
-        == 'PM7 1SCF GRADIENTS AUX(PRECISION=9) CHARGE=1 DOUBLET UHF'
-    )
-
-
-def test_mopac_unsupported_multiplicity():
-    with pytest.raises(ValueError, match='unsupported MOPAC multiplicity'):
-        _mopac_keyword_line('PM7', 0, 99)
 
 
 @pytest.mark.parametrize(
@@ -123,7 +30,7 @@ def test_tblite_method(method, expected):
 
 def test_tblite_method_unsupported():
     with pytest.raises(ValueError, match='unsupported xtb method'):
-        _tblite_method('pm7')
+        _tblite_method('bogus')
 
 
 def test_tblite_geometry_numbers_and_bohr_positions():


### PR DESCRIPTION
Makes GFN2-xTB (via `tblite`) the default energy/gradient backend across the docs, benchmarks, and CI, and removes every MOPAC trace from the repo.

## Source
- **`solvers.py`**: dropped `MopacSolver` and its AUX-parsing / keyword-line helpers; `XTBSolver` is now the documented backend referenced from `optimize.py`, `api.rst`, `getting-started.rst`, and `README.md`.
- **`geomlib.py`**: removed the `"mopac"` geometry output format (`Geometry.dump(f, 'mopac')`) and the `.mopac` write extension.

## Benchmarks
- Stripped `mopac_pm7_steps` from both `reference.json` files and rewrote the affected `SOURCE.md` passages.
- `benchmark.py` and `plan_batches.py` default to `xtb` and no longer offer a `mopac` solver; the regression-gate / cost-planning maps drop their mopac entries.
- `aggregate_benchmark.py`, `plot_convergence.py`, `molecule_gallery.{py,html}`, and the two SI converters updated to the xtb baseline (the gallery's semiempirical column now shows xTB GFN2 steps).

## CI / tooling
- `benchmark.yaml`: the push/PR auto-trigger and the `workflow_dispatch` default now use the cheap xtb pool; `xtb`/`pyscf`/`both` are the only solver options (neither has a fast/full split). MOPAC install step removed.
- `tests.yaml` and `copilot-setup-steps.yml` drop the MOPAC download; the session-start hook and `.gitignore` lose their MOPAC entries.

## Tests
- Integration tests (`test_optimize.py`) now drive `XTBSolver` (convergence-only, since xTB step counts aren't pinned to a historical baseline), guarded by a `tblite` skip.
- Removed the mopac-specific solver and geomlib dump tests.

## CHANGELOG
Added a `Removed` entry for `MopacSolver` and the `"mopac"` output format (a breaking change). Existing `[Unreleased]` entries that mention MopacSolver were left untouched.

## Verification
`scripts/check.sh` passes locally (ruff, black, mypy, pytest — 202 passed, sphinx `-W`). The matrix-builder in `benchmark.yaml` was exercised across push and `workflow_dispatch` cases, and an end-to-end `benchmark.py` run on small molecules converges under the new xtb default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dP3Ag5KKF3rowPpxvmZy)_