### PR TITLE
session-start: check out the reports branch as a worktree

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -14,3 +14,20 @@ cd "$CLAUDE_PROJECT_DIR"
 pip install -e ".[test,doc,benchmark]"
 
 pip install ruff black
+
+# Standalone investigation reports live on the `reports` orphan branch (one
+# YYYY-MM-DD-<slug>/ folder each, README.md as the main content), kept off the
+# package history on master. Check that branch out as a git worktree at
+# ./reports so past reports are available locally and new ones can be added
+# without mixing into the package tree; .gitignore keeps ./reports out of the
+# main working tree. See CLAUDE.md ("Investigation reports"). Every git call is
+# guarded so a missing branch or offline remote never aborts session start.
+reports_dir="$CLAUDE_PROJECT_DIR/reports"
+if [ ! -e "$reports_dir" ]; then
+  git fetch origin reports || true
+  if git show-ref --verify --quiet refs/heads/reports; then
+    git worktree add "$reports_dir" reports || true
+  elif git show-ref --verify --quiet refs/remotes/origin/reports; then
+    git worktree add --track -b reports "$reports_dir" origin/reports || true
+  fi
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /htmlcov/
 /poetry.lock
 /fort*
+# git worktree for the `reports` orphan branch, set up by the session-start hook
+/reports/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,26 @@ batch drifting past tolerance is flaky. Report these and move on; do not add
 coverage-gate config, loosen tolerances, or rewrite reference values to make
 them green.
 
+## Investigation reports
+
+Longer-form investigations — benchmark studies, root-cause write-ups, anything
+that produces a standalone report with prose, figures, and throwaway analysis
+scripts — do **not** live on `master`. They go on the `reports` orphan branch,
+which shares no history with `master` and holds nothing but the reports
+themselves, so the package tree stays free of one-off scratch material.
+
+Layout on `reports`: one top-level folder per report, named
+`YYYY-MM-DD-<slug>`, with the main content as `README.md` and all supporting
+files (figures, data, scripts) alongside it in that same folder. Keep each
+report self-contained in its folder.
+
+The session-start hook checks the `reports` branch out as a git worktree at
+`./reports` (ignored via `.gitignore`), so past reports are available locally
+in every session. To add one, create a new dated folder under `./reports`,
+commit it on the `reports` branch from that worktree, push, and open a PR
+**against `reports`** (not `master`). PRs that only add a report should target
+`reports`; code changes target `master` as usual.
+
 ## CHANGELOG
 
 `CHANGELOG.md` is reserved for important user-facing changes — new features,


### PR DESCRIPTION
Sets up the `reports` orphan branch (introduced for #148's investigation write-up) as a first-class place for standalone reports, and wires it into the dev environment.

## What this does

- **`session-start.sh`** — after the editable install, checks out the `reports` branch as a git **worktree** at `./reports`, so past investigation reports are available locally in every web session and new ones can be added without polluting the package tree. Every git call is guarded (`|| true`, `show-ref` checks) so a missing branch or offline remote never aborts session start; it creates a local tracking branch from `origin/reports` on first run and is a no-op once `./reports` exists.
- **`.gitignore`** — ignores `/reports/` so the worktree directory doesn't show up as untracked in the main checkout (verified: `git status` stays clean with the worktree present).
- **`CLAUDE.md`** — new "Investigation reports" section explaining the concept: reports live on the `reports` orphan branch, one `YYYY-MM-DD-<slug>/` folder each with `README.md` as the main content; report-only PRs target `reports`, code targets `master`.

## Background

The `reports` branch and its first report (`2026-06-20-baker-symmetry-saddle/`, the #148 symmetry-saddle investigation) are in PR #152. This PR makes the workflow reproducible for future reports.

I exercised the worktree logic locally: it checks out `reports` at `./reports` and `git status` correctly ignores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AZFVvf7GXgC3xZg5WCGFG

---
_Generated by [Claude Code](https://claude.ai/code/session_015AZFVvf7GXgC3xZg5WCGFG)_