### PR TITLE
Label report PRs with the report label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,9 @@ The session-start hook checks the `reports` branch out as a git worktree at
 `./reports` (ignored via `.gitignore`), so past reports are available locally
 in every session. To add one, create a new dated folder under `./reports`,
 commit it on the `reports` branch from that worktree, push, and open a PR
-**against `reports`** (not `master`). PRs that only add a report should target
-`reports`; code changes target `master` as usual.
+**against `reports`** (not `master`), and add the `report` label to it. PRs that
+only add a report should target `reports` and carry the `report` label; code
+changes target `master` as usual.
 
 ## CHANGELOG
 


### PR DESCRIPTION
Updates the "Investigation reports" instructions in `CLAUDE.md` so that PRs adding a report to the `reports` branch are also tagged with a `report` label, making them easy to filter from ordinary code PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkfRsBNtjhuuRfJGzA4ZT6)_