### PR TITLE
ci: bump actions to Node 24 majors to clear deprecation warnings

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -184,14 +184,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # The oligomers benchmark reads its geometries from the
           # external/oligomer-benchmarks submodule; harmless for the other
           # sets, whose geometries are package data.
           submodules: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Pin numeric-library threads to physical cores
@@ -224,7 +224,7 @@ jobs:
             --out-trace-dir "results"
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-${{ matrix.benchmark }}-${{ matrix.solver }}-${{ matrix.batch_id }}
           path: results/
@@ -245,11 +245,11 @@ jobs:
       group: ci-assets-publish
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: all-results
           pattern: benchmark-results-*
@@ -298,7 +298,7 @@ jobs:
         # at the artifact instead. Best-effort: a publish error must not fail
         # the Benchmark workflow (doc-deploy gates on it for master pushes).
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           SRC_BRANCH: ${{ github.head_ref || github.ref_name }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
@@ -426,7 +426,7 @@ jobs:
             await core.summary.write();
       - name: Upload summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-summary
           path: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -27,7 +27,7 @@ jobs:
 
       # Node is required by sphinxcontrib-katex's server-side prerender,
       # which scripts/check.sh and .github/workflows/doc.yaml both run.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/doc-deploy.yaml
+++ b/.github/workflows/doc-deploy.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Check all CI passed
         id: gate
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const trigger = context.payload.workflow_run;
@@ -57,7 +57,7 @@ jobs:
             core.setOutput('ok', 'true');
       - name: Download docs artifact
         if: steps.gate.outputs.ok == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs
           path: doc/build
@@ -65,10 +65,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload pages artifact
         if: steps.gate.outputs.ok == 'true'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: doc/build
       - name: Deploy
         if: steps.gate.outputs.ok == 'true'
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -11,14 +11,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       - name: Install
@@ -42,7 +42,7 @@ jobs:
       - name: Build molecule gallery
         if: github.event_name == 'push'
         run: python scripts/molecule_gallery.py -o doc/build/molecules.html
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: github.event_name == 'push'
         with:
           name: docs

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,8 +7,8 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -17,8 +17,8 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -27,8 +27,8 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,14 +12,14 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Populate external/oligomer-benchmarks so the oligomers benchmark's
           # geometry-loading path is exercised by test_benchmarks (it skips
           # when the submodule is absent).
           submodules: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       # tblite (the GFN-xTB backend behind berny.solvers.XTBSolver) lives in the
@@ -30,7 +30,7 @@ jobs:
       - name: Test
         run: coverage run -m pytest -v
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
## What

GitHub deprecated the **Node 20** runtime on its Actions runners ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Every action we pin that still declares `node20` was being force-run on Node 24, emitting a warning on every job, e.g. in the Tests workflow:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5, codecov/codecov-action@v4.
```

This bumps each pinned action to its current latest major, all of which ship a Node 24 runtime, clearing the warnings across all six workflows (tests, lint, doc, doc-deploy, benchmark, copilot-setup-steps).

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-python | v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/github-script | v7 | v9 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| codecov/codecov-action | v4 | v7 |

## Why no `with:` changes were needed

Release notes for each bump were checked against our specific usage:

- **checkout** — `fetch-depth`, `submodules`, `fetch-tags` unchanged; the v7 fork-PR restriction only affects `pull_request_target`/`workflow_run` triggers, which we don't use.
- **setup-node** — `node-version: "20"` (the doc-build KaTeX toolchain, unrelated to the runner) still resolves; v6 auto-cache doesn't trigger since there's no `package.json`.
- **github-script** — our inline scripts use only the injected `github`/`context`/`core` plus `require('fs')`/`require('path')`. The v9 ESM break is limited to `require('@actions/github')`; the v9 README confirms the proxy `require` still wraps Node built-ins.
- **upload/download-artifact** — inputs unchanged; uploads from v7 are downloadable by v8 (same v4-generation backend; only the v3→v4 boundary is incompatible).
- **codecov** — `token` / `fail_ci_if_error` inputs preserved across the v5 CLI rewrite.

## Validation

`scripts/check.sh` passes locally — ruff, black, mypy, pytest (207 passed, 1 skipped), and the strict Sphinx doc build are all green. The diff is workflow-YAML only and touches no package source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjnhgvQAXc3mduMH4QX1zb)_