### PR TITLE
Turn pytest warnings into errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,9 +85,8 @@ module = "tblite.*"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-# Turn warnings into errors (Python's -W error) so CI fails on new warnings;
-# the later filter keeps the pre-existing PendingDeprecationWarning ignored.
-filterwarnings = ["error", "ignore::PendingDeprecationWarning"]
+# Turn warnings into errors (Python's -W error) so CI fails on new warnings.
+filterwarnings = ["error"]
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,9 @@ module = "tblite.*"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-filterwarnings = ["ignore::PendingDeprecationWarning"]
+# Turn warnings into errors (Python's -W error) so CI fails on new warnings;
+# the later filter keeps the pre-existing PendingDeprecationWarning ignored.
+filterwarnings = ["error", "ignore::PendingDeprecationWarning"]
 testpaths = ["tests"]
 
 [tool.ruff]


### PR DESCRIPTION
## What

Enable `-W error` for pytest so warnings fail the test run.

This is done via pytest's `filterwarnings` ini option in `pyproject.toml`:

```toml
filterwarnings = ["error", "ignore::PendingDeprecationWarning"]
```

`error` turns all warnings into errors (the equivalent of Python's `-W error`), while the later `ignore::PendingDeprecationWarning` filter — which takes precedence — preserves the pre-existing ignore.

## Why config instead of a CI-only flag

`scripts/check.sh` and CI both invoke plain `pytest`, so configuring this in `pyproject.toml` means the local pre-push checks behave the same as CI. Per `CLAUDE.md`, catching CI failures locally is the whole point of `check.sh` — a CI-only `-W error` flag would let warning regressions slip past local checks.

## Verification

`pytest` passes cleanly with the new config (207 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBU47v7g3fUq2yvNX4YiNK)_