### PR TITLE
benchmark: note GFN2 conformer-energy artefact for ethanol/histidine (#154)

### DIFF
--- a/src/berny/benchmarks/baker_shajan_2023/SOURCE.md
+++ b/src/berny/benchmarks/baker_shajan_2023/SOURCE.md
@@ -69,6 +69,16 @@ whole Baker set is only ~3 s of compute under xTB; it runs as a single CI shard
 (``scripts/plan_batches.py --benchmark baker --solvers xtb --nbins 1``) -- extra
 shards would be dominated by per-job setup overhead.
 
+The ``.xyz`` start geometries are the canonical published Baker structures and
+are kept as-is. Note that GFN2-xTB can exaggerate small conformer-energy
+differences by ~1-2 kcal/mol relative to the HF/6-31G** reference, so a
+perturbed start occasionally relaxes to a *lower* GFN2 conformer than the
+unperturbed run (seen for ethanol and histidine). This reflects GFN2's
+conformer energetics, not a defect in the start geometries or step baselines:
+at the HF/6-31G** reference method the gap collapses to ~0.1 kcal/mol and, for
+ethanol, the bundled start's basin is the lower conformer outright. See
+issues #148/#154 for the full analysis.
+
 Coordinate data is treated as factual and is redistributed under
 pyberny's MPL-2.0 license, with attribution to Shajan et al. via this
 file and via the citation embedded in the comment line of each ``.xyz``.


### PR DESCRIPTION
Resolves the second group from #148 — the two **genuine-conformer** cases
(ethanol, histidine) tracked in #154.

## What this PR changes

A short note in `src/berny/benchmarks/baker_shajan_2023/SOURCE.md`. No data,
geometry, or step-baseline changes.

## Why

#154 asked the one open question for these two molecules (its Q3): the
noise-stability sweep found that perturbing the start lets **GFN2-xTB** reach a
1.5–2 kcal/mol "lower" conformer (ethanol gauche vs anti; histidine an
alternative rotamer). Does that ordering hold at the Baker paper's
**HF/6-31G\*\*** reference method?

It does not. Re-optimizing both conformers at GFN2-xTB and at HF/6-31G\*\* (via
PySCF, the engine `scripts/benchmark.py` uses):

| molecule | GFN2 gap | HF/6-31G\*\* gap | at HF the bundled reference is… |
|---|---:|---:|---|
| ethanol | −1.55 kcal/mol | **+0.08 kcal/mol** | the **lower** conformer (ordering reverses) |
| histidine | −1.98 kcal/mol | **−0.10 kcal/mol** | within 0.1 kcal/mol of the alternative |

The gap is a GFN2 conformer-energy artefact; at the reference method the
bundled Baker-start references are not sub-optimal. This is the gate in #154's
recommendation — with it failing, no benchmark-data change is warranted, so
this PR just records the fact for the next person.

Full analysis, geometries, and figure are in the investigation report
(separate PR against the `reports` branch:
`2026-06-20-baker-ethanol-histidine-conformer`).

Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdpT47VdZyPnQPAXhrr1Ld

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdpT47VdZyPnQPAXhrr1Ld)_