### PR TITLE
benchmark: break start-geometry symmetry before optimizing

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -105,8 +105,13 @@ def run_pyscf(name, ref, data_dir, trace=None):
             state['energies'].append(float(energy))
 
     # pyscf's berny_solver.kernel forwards unknown kwargs to the underlying
-    # Berny constructor, so ``trace=`` is propagated straight through.
-    kwargs = {'trace': str(trace)} if trace is not None else {}
+    # Berny constructor, so ``trace=`` and ``symmetry=`` are propagated
+    # straight through. ``symmetry='break'`` kicks an exactly symmetric start
+    # off its symmetry elements so the optimizer is not seeded on a symmetric
+    # saddle (issue #148).
+    kwargs = {'symmetry': 'break'}
+    if trace is not None:
+        kwargs['trace'] = str(trace)
     converged, _ = berny_solver.kernel(mf, callback=callback, **kwargs)
     return converged, state['n'], state['energies']
 
@@ -127,7 +132,10 @@ def run_xtb(name, ref, data_dir, trace=None):
     from berny.solvers import XTBSolver
 
     geom = geomlib.readfile(str(data_dir / ref.get('file', f'{name}.xyz')))
-    berny = Berny(geom, trace=trace)
+    # symmetry='break' kicks an exactly symmetric start off its symmetry
+    # elements so the optimizer is not seeded on a symmetric saddle (issue
+    # #148).
+    berny = Berny(geom, trace=trace, symmetry='break')
     solver = XTBSolver(charge=ref['charge'], mult=ref['mult'])
     energies = _optimize_recording_energies(berny, solver)
     return berny.converged, berny._n, energies

--- a/src/berny/benchmarks/baker_shajan_2023/reference.json
+++ b/src/berny/benchmarks/baker_shajan_2023/reference.json
@@ -8,7 +8,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 7,
-    "xtb_gfn2_steps": 6
+    "xtb_gfn2_steps": 43
   },
   "acetone": {
     "atoms": 10,
@@ -19,7 +19,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 5,
-    "xtb_gfn2_steps": 5
+    "xtb_gfn2_steps": 7
   },
   "acetylene": {
     "atoms": 4,
@@ -52,7 +52,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 4,
-    "xtb_gfn2_steps": 5
+    "xtb_gfn2_steps": 10
   },
   "ammonia": {
     "atoms": 4,
@@ -74,7 +74,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 6,
-    "xtb_gfn2_steps": 5
+    "xtb_gfn2_steps": 10
   },
   "benzene": {
     "atoms": 12,
@@ -85,7 +85,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 3,
-    "xtb_gfn2_steps": 3
+    "xtb_gfn2_steps": 10
   },
   "benzidine": {
     "atoms": 26,
@@ -96,7 +96,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 8,
-    "xtb_gfn2_steps": 8
+    "xtb_gfn2_steps": 17
   },
   "caffeine": {
     "atoms": 24,
@@ -107,7 +107,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 10,
-    "xtb_gfn2_steps": 7
+    "xtb_gfn2_steps": 47
   },
   "difluorobenzene_13": {
     "atoms": 12,
@@ -118,7 +118,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 4,
-    "xtb_gfn2_steps": 4
+    "xtb_gfn2_steps": 9
   },
   "difluoronaphthalene_15": {
     "atoms": 18,
@@ -129,7 +129,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 5,
-    "xtb_gfn2_steps": 4
+    "xtb_gfn2_steps": 10
   },
   "difuropyrazine": {
     "atoms": 16,
@@ -140,7 +140,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 7,
-    "xtb_gfn2_steps": 7
+    "xtb_gfn2_steps": 12
   },
   "dimethylpentane": {
     "atoms": 23,
@@ -173,7 +173,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 4,
-    "xtb_gfn2_steps": 4
+    "xtb_gfn2_steps": 5
   },
   "ethanol": {
     "atoms": 9,
@@ -184,7 +184,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 5,
-    "xtb_gfn2_steps": 5
+    "xtb_gfn2_steps": 7
   },
   "furan": {
     "atoms": 9,
@@ -195,7 +195,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 5,
-    "xtb_gfn2_steps": 5
+    "xtb_gfn2_steps": 8
   },
   "histidine": {
     "atoms": 20,
@@ -250,7 +250,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 7,
-    "xtb_gfn2_steps": 6
+    "xtb_gfn2_steps": 65
   },
   "methylamine": {
     "atoms": 7,
@@ -261,7 +261,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 4,
-    "xtb_gfn2_steps": 5
+    "xtb_gfn2_steps": 11
   },
   "naphthalene": {
     "atoms": 18,
@@ -272,7 +272,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 5,
-    "xtb_gfn2_steps": 4
+    "xtb_gfn2_steps": 9
   },
   "neopentane": {
     "atoms": 17,
@@ -283,7 +283,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 4,
-    "xtb_gfn2_steps": 3
+    "xtb_gfn2_steps": 6
   },
   "pterin": {
     "atoms": 17,
@@ -294,7 +294,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 8,
-    "xtb_gfn2_steps": 7
+    "xtb_gfn2_steps": 27
   },
   "trifluorobenzene_135": {
     "atoms": 12,
@@ -305,7 +305,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 4,
-    "xtb_gfn2_steps": 4
+    "xtb_gfn2_steps": 10
   },
   "trisilacyclohexane_135": {
     "atoms": 18,
@@ -316,7 +316,7 @@
     "paper_steps_basis": "6-31G**",
     "paper_steps_method": "HF",
     "pyberny_steps": 7,
-    "xtb_gfn2_steps": 7
+    "xtb_gfn2_steps": 8
   },
   "water": {
     "atoms": 3,

--- a/src/berny/benchmarks/oligomers/reference.json
+++ b/src/berny/benchmarks/oligomers/reference.json
@@ -469,7 +469,7 @@
     "mult": 1,
     "family": "propylene",
     "file": "propylene/polypropylene_n1.xyz",
-    "xtb_gfn2_steps": 3
+    "xtb_gfn2_steps": 7
   },
   "polypropylene_n2": {
     "atoms": 23,


### PR DESCRIPTION
## Summary

Switches both benchmark runners (xtb and pyscf) in `scripts/benchmark.py` to
drive optimization with `Berny(symmetry='break')`, the opt-in symmetry-breaking
kick added in #162 in response to #148, and re-seeds the affected step-count
references to the broken-start runs.

A gradient-following optimizer seeded on an exactly symmetric start geometry
cannot leave the symmetric subspace, so it can converge to a symmetric **saddle**
above the true minimum. `symmetry='break'` displaces the start off its symmetry
elements so the optimizer is no longer trapped.

## Effect across the three sets (dispatched on this branch)

- **birkholz** — no change; all 19 starts are `C1`, on which the kick is a no-op. Green.
- **oligomers** — only `polypropylene_n1` (Cₛ) moves (3→7 steps, same minimum); the other 90 are `C1`.
- **baker** — 23/30 symmetric. Six descend to genuinely lower minima (the #148 saddles, ΔE up to 6.24 kcal/mol; matches the issue table); the rest re-converge to the same energy at higher step cost.

Full investigation: PR #166 (against `reports`).

## Reference re-seeding

The shipped `xtb_gfn2_steps` baselines were measured against the old
symmetric-saddle convergence, so they no longer describe the broken-start run.
Re-seeded to the broken-start step counts measured on the dispatched CI runs:
20 baker molecules + `polypropylene_n1` (birkholz unchanged). The benchmark step
gate is **green** again with the new baselines.

## Status

- [x] Switch xtb + pyscf runners to `symmetry='break'`
- [x] Manually dispatch all three benchmark sets (birkholz / baker / oligomers)
- [x] Investigate the differences (→ #166)
- [x] Re-seed the moved references; benchmark checks green

> [!NOTE]
> The `mypy` check on this branch is red due to **pre-existing** numpy-2.5 stub
> drift on master, unrelated to this PR. Fixed separately in #167; this branch
> goes fully green once #167 lands and this rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)