### PR TITLE
ci: cap numpy &lt;2.5 for the mypy type check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,5 +38,11 @@ jobs:
       - name: Install dependencies
         # Install the package so mypy picks up bundled NumPy stubs and our own
         # type hints via the installed module rather than just the source tree.
-        run: pip install -e . mypy
+        # numpy is capped <2.5 for the type check only: numpy 2.5's bundled
+        # stubs use a PEP 695 `type` statement that mypy rejects under our
+        # python_version=3.10 target (which is what keeps the codebase
+        # 3.10-compatible; 2.4.x stubs type-check cleanly). Runtime and the test
+        # matrix still run unpinned numpy. Keep in sync with the dev group in
+        # pyproject.toml.
+        run: pip install -e . mypy 'numpy<2.5'
       - run: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,11 @@ plot = ["matplotlib"]
 ruff = "==0.15.18"
 black = ">=22"
 mypy = ">=1"
+# numpy capped <2.5 for the mypy type check: numpy 2.5's bundled stubs use a
+# PEP 695 `type` statement that mypy rejects under python_version=3.10. 2.4.x
+# stubs type-check cleanly; runtime is unconstrained by the main dependency.
+# Keep in sync with the mypy job in .github/workflows/lint.yaml.
+numpy = "<2.5"
 
 [tool.poetry.scripts]
 berny = "berny.cli:main"


### PR DESCRIPTION
## Summary

The `mypy` lint job has been failing on every push (master included) since
numpy **2.5.0** became the default install:

```
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
```

numpy 2.5.0's bundled stubs use a PEP 695 `type` statement, which mypy refuses
to parse under the repo's `python_version = "3.10"` target. The 3.10 target is
deliberate (it's what keeps the codebase 3.10-compatible), so bumping it isn't
the fix — and bumping it to 3.12 locally surfaces 4 unrelated numpy-stub type
errors, i.e. it's a behaviour change, not a clean fix.

## Fix

Cap **numpy `<2.5` for type-checking only** — its 2.4.x stubs check cleanly —
in two synced places, mirroring the existing ruff pin-and-sync convention:

- `.github/workflows/lint.yaml` mypy job: `pip install -e . mypy 'numpy<2.5'`
- `pyproject.toml` `[tool.poetry.group.dev.dependencies]`: `numpy = "<2.5"`

Runtime (the main `numpy<3,>=1.21` dependency) and the test matrix keep
installing numpy unpinned, so the package still ships and is tested against the
latest numpy — only the type-check environment is capped.

Verified locally: `mypy` is clean against numpy 2.4.6 at the 3.10 target.

This is independent of the benchmark symmetry-breaking work (#164); it just
unblocks the shared `mypy` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABF8fpXRVZaJEGjtNJo7qT)_