### PR TITLE
build: enable additional strict mypy checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,12 @@ files = ["src/berny"]
 strict = true
 warn_unreachable = true
 extra_checks = true
+# Treat bytes/bytearray/memoryview as distinct (the mypy 2.0 default, opted
+# into early).
+strict_bytes = true
 disallow_any_unimported = true
+# Flag implicit Any leaking in through untyped decorators.
+disallow_any_decorated = true
 enable_error_code = [
     "redundant-self",
     "redundant-expr",
@@ -88,6 +93,12 @@ enable_error_code = [
     "truthy-iterable",
     "ignore-without-code",
     "unused-awaitable",
+    # Error on use of @deprecated-marked symbols (PEP 702).
+    "deprecated",
+    # Require match statements over enums/literals/unions to be exhaustive.
+    "exhaustive-match",
+    # Flag reveal_type/reveal_locals left in without an explicit import.
+    "unimported-reveal",
 ]
 
 # tblite ships no type stubs; XTBSolver imports it lazily and uses it only at


### PR DESCRIPTION
## Summary

The mypy config was already fairly strict (`strict = true`, `warn_unreachable`, `extra_checks`, `disallow_any_unimported`, plus several enabled error codes). This turns on a handful of *additional* strictness knobs that the codebase **already satisfies**, so there are no source changes — only `[tool.mypy]` config.

Added flags:

- **`strict_bytes`** — treat `bytes`/`bytearray`/`memoryview` as distinct types (this becomes the default in mypy 2.0; opting in early)
- **`disallow_any_decorated`** — flag implicit `Any` leaking in through untyped decorators
- error code **`deprecated`** — error on use of `@deprecated`-marked symbols (PEP 702)
- error code **`exhaustive-match`** — require `match` statements over enums/literals/unions to be exhaustive
- error code **`unimported-reveal`** — flag stray `reveal_type`/`reveal_locals` left in without an explicit import

## Considered but left out

These require actual code changes, so they're omitted to keep the change source-free:

- **`disallow_any_explicit`** (~37 errors) / **`disallow_any_expr`** (~717 errors) — too invasive
- error code **`mutable-override`** (3 errors) — the `Bond`/`Angle`/`Dihedral` subclasses narrow the mutable `idx: tuple[int, ...]` attribute to fixed-length tuples; a clean fix means making `idx` read-only
- error code **`explicit-override`** (31 errors) — would require adding `@override` decorators across the coordinate/solver hierarchies

Note: error codes `redundant-cast`, `comparison-overlap`, `unused-ignore`, and `narrowed-type-not-subtype` were *not* added because they're already implied by `strict`/`extra_checks` and would be no-ops.

## Verification

`python -m mypy` → `Success: no issues found in 15 source files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBUGnUPk5y6r2NfmbDu4tG)_