### PR TITLE
bench: run PySCF benchmark with density fitting

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -96,6 +96,12 @@ def run_pyscf(name, ref, data_dir, trace=None):
         mf.xc = 'b3lyp'
     else:
         raise ValueError(f'unsupported paper method {method!r}')
+    # Approximate the four-center two-electron integrals with the RI /
+    # density-fitting expansion (auto-generated auxiliary basis for the chosen
+    # orbital basis). This cuts the per-SCF-and-gradient cost substantially; the
+    # benchmark records how the resulting (slightly different) PES affects
+    # pyberny's step counts versus the conventional integrals run on master.
+    mf = mf.density_fit()
     state = {'n': 0, 'energies': []}
 
     def callback(loc):


### PR DESCRIPTION
## What

Apply `.density_fit()` to the PySCF mean-field object in `run_pyscf` (`scripts/benchmark.py`) so the SCF energies and gradients use the RI / density-fitting (DF) approximation — with PySCF's auto-generated auxiliary basis for the chosen orbital basis — instead of the conventional four-center two-electron integrals used on `master`.

```python
mf = mf.density_fit()
```

## Why

On `master`, `run_pyscf` builds a plain `scf.RHF`/`UHF` or `dft.RKS`/`UKS` object with exact ERIs. This PR is a controlled A/B: same molecules, same basis, same method, differing only in DF vs exact integrals, so we can isolate how DF's slightly different PES affects pyberny's optimization step counts (and how much faster the per-call cost gets).

## How to compare

Trigger the Benchmark workflow (`workflow_dispatch`) with `benchmark = birkholz`, `solver = pyscf` on:
- `master` → conventional integrals (baseline)
- this branch → density fitting

Then diff the aggregated step counts / convergence plots between the two runs.

## Notes

- Scoped to the benchmark runner only — no `berny` source changes.
- `scripts/plan_batches.py` shard timings are left as-is; DF makes per-call cost cheaper, so the existing LPT-balanced shards are conservative (shards will simply finish faster).
- No CHANGELOG entry: benchmark-tooling change, not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4Ynes49WQs42j3AFbsi4X)_