### PR TITLE
Fix web-session git rewrite so non-origin GitHub deps resolve

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,6 +6,23 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 cd "$CLAUDE_PROJECT_DIR"
+
+# The web sandbox routes every github.com URL through a repo-scoped git relay
+# (a catch-all `url.<relay>.insteadOf = https://github.com/`). That relay 403s
+# every repo except this one, which breaks the `molsym` git dependency pulled in
+# by the pip install below. Narrow the rewrite to just `origin` so all other
+# github.com URLs fall through to the egress proxy (which permits them). The
+# `case` guard means we only act on a real relay URL and never write a malformed
+# empty-section entry when `git remote get-url origin` returns nothing.
+origin_url=$(git remote get-url origin 2>/dev/null || true)
+case "$origin_url" in
+  *//*/git/*)
+    repo_path=${origin_url##*/git/}
+    git config --global --unset-all url."${origin_url%"$repo_path"}".insteadOf 2>/dev/null || true
+    git config --global url."$origin_url".insteadOf "https://github.com/$repo_path"
+    ;;
+esac
+
 # [doc] is needed for the sphinx-build step in scripts/check.sh. The Sphinx
 # step relies on `node` for sphinxcontrib-katex's server-side prerender; the
 # Claude Code on the web base image ships node, so no extra install is required


### PR DESCRIPTION
## Problem

In Claude Code web sessions, `pip install -e ".[test,doc,benchmark]"` in `session-start.sh` was failing silently, leaving `berny` not importable and `scripts/check.sh` unrunnable.

Root cause: the web sandbox installs a **catch-all** git rewrite — `url.<relay>.insteadOf = https://github.com/` — that funnels *every* `github.com` URL through a repo-scoped git relay. The relay returns **403** for every repo except `origin`. Since `pyberny` declares a git dependency on a *different* repo:

```toml
molsym = { git = "https://github.com/jhrmnn/molsym.git", branch = "claude/qcelemental-optional-iosjwj" }
```

pip could never clone `molsym`, so the editable install aborted.

An earlier env-level fix attempt mis-fired: it ran when `git remote get-url origin` returned empty, so instead of narrowing the rewrite it left the broad catch-all untouched and appended a malformed `[url ""] insteadOf = https://github.com/` entry.

## Fix

Narrow the rewrite to **just `origin`** at the top of `session-start.sh` (before the `pip install`), so all other `github.com` URLs fall through to the egress proxy, which permits them:

```sh
origin_url=$(git remote get-url origin 2>/dev/null || true)
case "$origin_url" in
  *//*/git/*)
    repo_path=${origin_url##*/git/}
    git config --global --unset-all url."${origin_url%"$repo_path"}".insteadOf 2>/dev/null || true
    git config --global url."$origin_url".insteadOf "https://github.com/$repo_path"
    ;;
esac
```

Running it from the hook guarantees correct timing (after the repo clone and after the platform installs the catch-all) and correct cwd. The `case` guard means it only ever rewrites a genuine relay URL and never writes the malformed empty-section entry when `origin` can't be read.

## Validation

- `bash -n` passes; both code paths exercised under `set -euo pipefail`:
  - relay `origin` → broad catch-all replaced by per-repo rewrite
  - empty `origin` → no junk written, no abort (exit 0)
- With the rewrite applied live, `pyberny` still routes through the scoped relay (in-scope), while `molsym` and `pyscf` resolve via the egress proxy.
- `pip install -e ".[test,doc,benchmark]"` now completes: `molsym` clones + builds, `pyberny` installs, `import berny, molsym` succeeds.

No `CHANGELOG` entry — this is an internal web-session setup fix with no user-facing effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KedZEZuZqognUThTZ6GSUG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KedZEZuZqognUThTZ6GSUG)_