### PR TITLE
Add PyPI publishing workflows mirroring libmbd

### DIFF
--- a/.github/workflows/build-dist.yaml
+++ b/.github/workflows/build-dist.yaml
@@ -1,0 +1,44 @@
+name: Build distributions
+on:
+  # Validate packaging changes on PRs and master, and build the release
+  # artifacts when a GitHub Release is published. The Publish workflow reacts
+  # to a successful release build via workflow_run and uploads the result.
+  pull_request:
+    paths:
+      - '.github/workflows/build-dist.yaml'
+      - 'pyproject.toml'
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/build-dist.yaml'
+      - 'pyproject.toml'
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  build:
+    name: Build
+    if: github.repository == 'jhrmnn/pyberny' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # poetry-dynamic-versioning derives the version from Git tags, so the
+          # full history (and tags) must be available.
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+      # pyberny is pure Python, so a single sdist + universal wheel built here
+      # serves every supported interpreter and is what gets uploaded to PyPI.
+      - name: Build sdist and wheel
+        run: python -m build --outdir dist
+      - name: Check metadata
+        run: twine check --strict dist/*
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: pyberny-dist
+          path: dist/*

--- a/.github/workflows/build-dist.yaml
+++ b/.github/workflows/build-dist.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     name: Build
-    if: github.repository == 'jhrmnn/pyberny' || github.event_name == 'pull_request'
+    if: github.repository == 'pyberny/pyberny' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,57 @@
+name: Publish
+# Reacts to a completed "Build distributions" run rather than triggering on the
+# release directly. Like the doc-deploy trigger, workflow_run keeps this
+# privileged workflow off of pull requests entirely, so PRs never show skipped
+# publish checks. The job only acts when the build it is reacting to was for a
+# published GitHub Release that succeeded.
+on:
+  workflow_run:
+    workflows: [Build distributions]
+    types: [completed]
+jobs:
+  publish:
+    name: Publish to PyPI and GitHub Release
+    if: >-
+      github.repository == 'jhrmnn/pyberny' &&
+      github.event.workflow_run.event == 'release' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pyberny/
+    permissions:
+      # Mint a short-lived OIDC token for PyPI trusted publishing; no API token
+      # secret is stored in the repository.
+      id-token: write
+      # Attach the source archives to the GitHub Release.
+      contents: write
+      # Download the build artifacts from the triggering workflow run.
+      actions: read
+    steps:
+      # Artifacts live in the triggering run, so they must be fetched by its id
+      # (workflow_run does not carry them across automatically).
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: pyberny-dist
+          path: dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # PyPI uploads are immutable, but the GitHub Release asset step below can
+      # still fail transiently. skip-existing keeps the whole workflow safely
+      # re-runnable: a re-run no-ops the already-published files instead of
+      # erroring, so it can get through to (re)attach the release assets.
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+      # Mirror the sdist and wheel onto the GitHub Release alongside GitHub's
+      # auto-generated source code archives. The release build ran on the tag,
+      # so the triggering run's head_branch is the release tag. GH_REPO lets gh
+      # find the repo without a checkout.
+      - name: Attach distributions to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.workflow_run.head_branch }}
+        run: gh release upload "$TAG" dist/* --clobber

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
   publish:
     name: Publish to PyPI and GitHub Release
     if: >-
-      github.repository == 'jhrmnn/pyberny' &&
+      github.repository == 'pyberny/pyberny' &&
       github.event.workflow_run.event == 'release' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sets up a release pipeline modeled on [`libmbd/libmbd`](https://github.com/libmbd/libmbd)'s `build-dist.yaml` + `publish.yaml` pair.

## What's added

- **`.github/workflows/build-dist.yaml`** — builds the sdist and (pure-Python) wheel, runs `twine check --strict`, and uploads them as the `pyberny-dist` artifact. Triggers on PRs/master pushes that touch packaging files, on published GitHub Releases, and on manual `workflow_dispatch`.
- **`.github/workflows/publish.yaml`** — reacts to a successful **Build distributions** run via `workflow_run`. When that run was for a published release, it publishes to PyPI via OIDC **trusted publishing** (no API token stored in the repo) and attaches the distributions to the GitHub Release. Routing through `workflow_run` keeps this privileged job off pull requests entirely.

## How it differs from libmbd

libmbd ships a C extension built against an external libMBD, so it publishes an sdist only and bundles a separate Fortran/C source archive. pyberny is pure Python, so the source-archive machinery (`devtools/source-dist.sh`, `cffi_build.py`) is dropped and the workflow builds a universal wheel alongside the sdist. Action versions match the rest of this repo (`checkout@v7`, `setup-python@v6`, `upload-artifact@v7`, `download-artifact@v8`). The owner guards target `pyberny/pyberny` (post-transfer).

## Verification

`python -m build` produces both artifacts and `twine check --strict` passes on both in a clean environment. After rebasing onto master (which now depends on `molsym>=0.2.1` from PyPI), the package metadata carries `Requires-Dist: molsym (>=0.2.1)` with **no git URL** — so the previous PyPI-upload blocker is resolved.

## Before the first real publish

One repo-side prerequisite remains for `publish.yaml` to actually upload:

- Configure a **PyPI trusted publisher** for the `pyberny` project (publisher: this repo, workflow `publish.yaml`, environment `pypi`) and create a GitHub Actions **environment named `pypi`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtwsJMivECxUBCJQdcP684