### PR TITLE
Point repository and docs references at the pyberny org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,5 +51,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CLI
 
-[unreleased]: https://github.com/jhrmnn/pyberny/compare/0.6.3...HEAD
-[0.6.3]: https://github.com/jhrmnn/pyberny/releases/tag/0.6.3
+[unreleased]: https://github.com/pyberny/pyberny/compare/0.6.3...HEAD
+[0.6.3]: https://github.com/pyberny/pyberny/releases/tag/0.6.3

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PyBerny
 
-![checks](https://img.shields.io/github/checks-status/jhrmnn/pyberny/master.svg)
-[![coverage](https://img.shields.io/codecov/c/github/jhrmnn/pyberny.svg)](https://codecov.io/gh/jhrmnn/pyberny)
+![checks](https://img.shields.io/github/checks-status/pyberny/pyberny/master.svg)
+[![coverage](https://img.shields.io/codecov/c/github/pyberny/pyberny.svg)](https://codecov.io/gh/pyberny/pyberny)
 ![python](https://img.shields.io/pypi/pyversions/pyberny.svg)
 [![pypi](https://img.shields.io/pypi/v/pyberny.svg)](https://pypi.org/project/pyberny/)
-[![commits since](https://img.shields.io/github/commits-since/jhrmnn/pyberny/latest.svg)](https://github.com/jhrmnn/pyberny/releases)
-[![last commit](https://img.shields.io/github/last-commit/jhrmnn/pyberny.svg)](https://github.com/jhrmnn/pyberny/commits/master)
-[![license](https://img.shields.io/github/license/jhrmnn/pyberny.svg)](https://github.com/jhrmnn/pyberny/blob/master/LICENSE)
+[![commits since](https://img.shields.io/github/commits-since/pyberny/pyberny/latest.svg)](https://github.com/pyberny/pyberny/releases)
+[![last commit](https://img.shields.io/github/last-commit/pyberny/pyberny.svg)](https://github.com/pyberny/pyberny/commits/master)
+[![license](https://img.shields.io/github/license/pyberny/pyberny.svg)](https://github.com/pyberny/pyberny/blob/master/LICENSE)
 [![code style](https://img.shields.io/badge/code%20style-black-202020.svg)](https://github.com/ambv/black)
 [![doi](https://img.shields.io/badge/doi-10.5281%2Fzenodo.3695037-blue)](http://doi.org/10.5281/zenodo.3695037)
 
@@ -14,9 +14,9 @@ PyBerny is an optimizer of molecular geometries with respect to the total energy
 
 In each step, it takes energy and Cartesian gradients as an input, and returns a new equilibrium structure estimate.
 
-The package implements a single optimization algorithm, which is an amalgam of several techniques, comprising the quasi-Newton method, redundant internal coordinates, an iterative Hessian approximation, a trust region scheme, linear search, and coordinate weighting. The algorithm is described in more detail in the [documentation](https://jhrmnn.github.io/pyberny/master/algorithm.html).
+The package implements a single optimization algorithm, which is an amalgam of several techniques, comprising the quasi-Newton method, redundant internal coordinates, an iterative Hessian approximation, a trust region scheme, linear search, and coordinate weighting. The algorithm is described in more detail in the [documentation](https://pyberny.nablapsi.science/master/algorithm.html).
 
-Several desirable features are missing or incomplete at the moment, some of them being actively worked on (help is always welcome): [crystal geometries](https://github.com/jhrmnn/pyberny/issues/5), [coordinate constraints](https://github.com/jhrmnn/pyberny/issues/14), [coordinate weighting](https://github.com/jhrmnn/pyberny/issues/32), [transition state search](https://github.com/jhrmnn/pyberny/issues/4).
+Several desirable features are missing or incomplete at the moment, some of them being actively worked on (help is always welcome): [crystal geometries](https://github.com/pyberny/pyberny/issues/5), [coordinate constraints](https://github.com/pyberny/pyberny/issues/14), [coordinate weighting](https://github.com/pyberny/pyberny/issues/32), [transition state search](https://github.com/pyberny/pyberny/issues/4).
 
 PyBerny is available in [PySCF](https://sunqm.github.io/pyscf/geomopt.html#pyberny) and [QCEngine](http://docs.qcarchive.molssi.org/projects/QCEngine/en/latest/index.html?highlight=pyberny#backends).
 
@@ -44,7 +44,7 @@ relaxed = optimize(optimizer, XTBSolver())
 
 To plug in a different backend, replace `XTBSolver()` with any
 coroutine that follows the same interface (see the
-[documentation](https://jhrmnn.github.io/pyberny/master/getting-started.html)
+[documentation](https://pyberny.nablapsi.science/master/getting-started.html)
 for the manual generator pattern and the solver protocol).
 
 ## Citing
@@ -56,4 +56,4 @@ for citing a specific version.
 
 ## Links
 
-- Documentation: https://jhrmnn.github.io/pyberny
+- Documentation: https://pyberny.nablapsi.science

--- a/doc/algorithm.rst
+++ b/doc/algorithm.rst
@@ -9,7 +9,7 @@ treatment of the SM itself, with every equation needed to reimplement it
 and an explicit catalogue of PyBerny's deviations, see
 :doc:`standard_method`.
 
-.. todo:: Make the algorithm `fully conform <https://github.com/jhrmnn/pyberny/issues/29>`_ to the SM.
+.. todo:: Make the algorithm `fully conform <https://github.com/pyberny/pyberny/issues/29>`_ to the SM.
 
 Sketch of the algorithm
 -----------------------
@@ -57,7 +57,7 @@ Redundant internal coordinates
 5. In the case of a crystal, just the internal coordinate closest to the
    original unit cell is retained from all its periodic images.
 
-.. todo:: Implement `linear bends <https://github.com/jhrmnn/pyberny/issues/30>`_.
+.. todo:: Implement `linear bends <https://github.com/pyberny/pyberny/issues/30>`_.
 
 Generalized inverse
 -------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,7 +62,7 @@ html_theme = 'alabaster'
 html_theme_options = {
     'description': description,
     'github_button': True,
-    'github_user': 'jhrmnn',
+    'github_user': 'pyberny',
     'github_repo': 'pyberny',
     'badge_branch': 'master',
     'codecov_button': True,

--- a/doc/standard_method.rst
+++ b/doc/standard_method.rst
@@ -232,7 +232,7 @@ constraint if needed.
 
 :pb:`Not implemented in PyBerny.` Linear-bend handling via dummy atoms is
 open issue
-`#30 <https://github.com/jhrmnn/pyberny/issues/30>`_. PyBerny currently
+`#30 <https://github.com/pyberny/pyberny/issues/30>`_. PyBerny currently
 just skips dihedrals through nearly-linear angles (within
 :math:`5°` of :math:`0` or :math:`\pi`; see ``lin_thre`` in
 :func:`berny.coords.get_dihedrals`) via a recursive "chain through the
@@ -494,7 +494,7 @@ following rules.
 
 :pb:`Not implemented in PyBerny.` Only minimisation is supported. TS
 support is part of open issue
-`#29 <https://github.com/jhrmnn/pyberny/issues/29>`_.
+`#29 <https://github.com/pyberny/pyberny/issues/29>`_.
 
 
 Trust region
@@ -794,8 +794,8 @@ PyBerny vs. SM at a glance
      - not used
      - quartic-then-cubic between best and current
 
-.. _#29: https://github.com/jhrmnn/pyberny/issues/29
-.. _#30: https://github.com/jhrmnn/pyberny/issues/30
+.. _#29: https://github.com/pyberny/pyberny/issues/29
+.. _#30: https://github.com/pyberny/pyberny/issues/30
 
 
 Additional references

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ version = "0.0.0"
 description = "Molecular/crystal structure optimizer"
 readme = "README.md"
 authors = ["Jan Hermann <dev@jan.hermann.name>"]
-repository = "https://github.com/jhrmnn/pyberny"
-documentation = "https://jhrmnn.github.io/pyberny"
+repository = "https://github.com/pyberny/pyberny"
+documentation = "https://pyberny.nablapsi.science"
 license = "MPL-2.0"
 packages = [
     { include = "berny", from = "src" },


### PR DESCRIPTION
## Summary

Prepares the repo for transfer from `jhrmnn/pyberny` to the new **pyberny** GitHub org by updating in-repo references. Intended to merge right after the transfer.

- **Owner refs** `jhrmnn/pyberny` → `pyberny/pyberny`: README badges/links, `CHANGELOG.md` compare/release links, issue cross-references in `doc/standard_method.rst` and `doc/algorithm.rst`, and the docs theme's `github_user` in `doc/conf.py`.
- **Docs URLs** `jhrmnn.github.io/pyberny` → `pyberny.nablapsi.science`: `pyproject.toml` `documentation` and the README doc links. The custom domain is decoupled from GitHub ownership, so the public docs URL is unaffected by the transfer.

The `jhrmnn/molsym` git dependency in `pyproject.toml` is intentionally left unchanged — it's a separate repository, not part of this transfer.

## Out-of-repo follow-ups (not covered by this PR)

These are done on GitHub / DNS, outside this repo:

- **DNS/Pages**: repoint the `pyberny.nablapsi.science` CNAME from `jhrmnn.github.io` to `pyberny.github.io`, re-set the custom domain in the org repo's Pages settings, re-enable *Enforce HTTPS* (cert re-provisions), and add the org's domain-verification record.
- **Codecov**: re-link the repo under the org (badge path changes).
- **Zenodo**: re-enable the release-archiving webhook.
- Verify repo secrets, the `github-pages` environment, and branch protection after transfer.

The `github.com/jhrmnn/pyberny` → `pyberny/pyberny` redirect and the `jan.hermann.name/pyberny` → `pyberny.nablapsi.science` redirect both survive the transfer automatically.

## Verification

`scripts/check.sh`: the Sphinx `-W -E` doc build (the only check these edits affect), `black`, and `pytest` pass. `ruff`/`mypy` were not run cleanly in this environment (installed ruff is 0.15.20 vs. the pinned 0.15.18, flagging a pre-existing `# noqa` in an untouched file; mypy isn't installed) — both are green under CI's pinned toolchain, and all changed files pass ruff individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BcanZF85fRSo2a6juRHkt

---
_Generated by [Claude Code](https://claude.ai/code/session_019BcanZF85fRSo2a6juRHkt)_