### PR TITLE
Depend on molsym from PyPI instead of a git fork

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -7,22 +7,6 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# The web sandbox routes every github.com URL through a repo-scoped git relay
-# (a catch-all `url.<relay>.insteadOf = https://github.com/`). That relay 403s
-# every repo except this one, which breaks the `molsym` git dependency pulled in
-# by the pip install below. Narrow the rewrite to just `origin` so all other
-# github.com URLs fall through to the egress proxy (which permits them). The
-# `case` guard means we only act on a real relay URL and never write a malformed
-# empty-section entry when `git remote get-url origin` returns nothing.
-origin_url=$(git remote get-url origin 2>/dev/null || true)
-case "$origin_url" in
-  *//*/git/*)
-    repo_path=${origin_url##*/git/}
-    git config --global --unset-all url."${origin_url%"$repo_path"}".insteadOf 2>/dev/null || true
-    git config --global url."$origin_url".insteadOf "https://github.com/$repo_path"
-    ;;
-esac
-
 # [doc] is needed for the sphinx-build step in scripts/check.sh. The Sphinx
 # step relies on `node` for sphinxcontrib-katex's server-side prerender; the
 # Claude Code on the web base image ships node, so no extra install is required

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,9 @@ pyscf = { version = ">=2.5", optional = true }
 matplotlib = { version = ">=3.5", optional = true }
 tblite = { version = ">=0.3", optional = true }
 # Point-group detection + symmetry-adapted displacement coordinates for the
-# `symmetry` argument of Berny. Tracked on a fork branch with qcelemental made
-# optional so the dependency stays numpy-only. NB: this git URL blocks a clean
-# PyPI upload of pyberny; swap it for a version spec once MolSym is on PyPI.
-molsym = { git = "https://github.com/jhrmnn/molsym.git", branch = "claude/qcelemental-optional-iosjwj" }
+# `symmetry` argument of Berny. qcelemental is an optional extra of MolSym, so
+# the dependency stays numpy-only.
+molsym = ">=0.2.1"
 
 [tool.poetry.extras]
 test = ["pytest", "coverage"]


### PR DESCRIPTION
## Summary

MolSym [0.2.1](https://pypi.org/project/molsym/0.2.1/) is now published on PyPI, with `qcelemental` as an optional extra rather than a hard requirement. That is exactly the property the fork branch (`claude/qcelemental-optional-iosjwj`) provided, so pyberny can now depend on the upstream package directly.

- **`pyproject.toml`**: replace the `molsym = { git = "https://github.com/jhrmnn/molsym.git", branch = ... }` dependency with a plain `molsym = ">=0.2.1"` version spec. The dependency stays numpy-only because `qcelemental` is an optional MolSym extra. This also unblocks a clean PyPI upload of pyberny itself (a git URL in the dependency tree previously prevented it).
- **`.claude/hooks/session-start.sh`**: remove the web-sandbox git-relay workaround. Its only purpose was to let the `molsym` git dependency resolve through github.com during `pip install`; with molsym coming from PyPI it is dead code.

The `molsym` API used by `berny.symmetry` (`Molecule`, `Symtext.from_molecule`, `salcs.cartesian_coordinates.CartesianCoordinates`, `salcs.projection_op.ProjectionOp`) is unchanged in 0.2.1.

## Testing

Ran the full pre-push suite (`scripts/check.sh`) against molsym 0.2.1 from PyPI:

- `ruff check` (0.15.18) — passed
- `black --check` — passed
- `mypy` — passed (15 source files)
- `pytest` — 225 passed, 1 skipped (all 16 symmetry tests included)
- `sphinx-build -W` — build succeeded

No CHANGELOG entry: the `molsym`-backed `symmetry` feature is already covered by an existing unreleased entry, and the git-vs-PyPI source is an internal packaging detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaQVJuN8idaX3iQk3rvdYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaQVJuN8idaX3iQk3rvdYn)_